### PR TITLE
Updated deploy for pupgrade

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,7 +12,7 @@ set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app
-set :deploy_to, '/home/lyberadmin/gis-robot-suite'
+set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 
 # Default value for :scm is :git
 # set :scm, :git
@@ -40,7 +40,7 @@ set :scm, :git
 
 set :stages, %w(development staging production)
 set :default_stage, 'development'
-set :linked_dirs, %w(log run config/environments config/certs)
+set :linked_dirs, %w(log run config/environments)
 
 namespace :deploy do
   # This is a try to configure a clean install

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,4 +4,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'staging'
 set :whenever_environment, 'stage'
-set :default_env, robot_environment: 'stage'
+set :default_env, robot_environment: 'staging'


### PR DESCRIPTION
The new kurma-robots1 vms place the app in `/opt/app`. The certs now live in `/etc/pki/tls`, and stage would only deploy if `robot_environment` was reconfigured to `staging` from `stage`.