### PR TITLE
bundle update dor-services to 5.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'assembly-objectfile', '~> 1.6.6'
 gem 'bundler', '~> 1.10'
-gem 'dor-services', '~> 5.4', '>= 5.4.2'
+gem 'dor-services', '~> 5.8', '>= 5.8.2'
 gem 'fastimage', '~> 1.7'
 gem 'ffi-geos', '~> 1.0'          # XXX: where is this used?
 gem 'lyber-core', '~> 4.0', '>= 4.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     confstruct (0.2.7)
     daemons (1.2.3)
     dbf (3.0.5)
-    deprecation (0.2.2)
+    deprecation (1.0.0)
       activesupport
     diff-lcs (1.2.5)
     dlss-capistrano (3.2.0)
@@ -66,16 +66,16 @@ GEM
       capistrano-releaseboard
     docile (1.1.5)
     docopt (0.5.0)
-    domain_name (0.5.20160216)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
-    dor-rights-auth (1.0.2)
+    dor-rights-auth (1.2.0)
       nokogiri
-    dor-services (5.4.2)
+    dor-services (5.8.2)
       active-fedora (~> 6.0)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
       dor-rights-auth (~> 1.0, >= 1.0.2)
-      dor-workflow-service (~> 2.0)
+      dor-workflow-service (~> 2.0, >= 2.0.1)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
       json (~> 1.8.1)
@@ -84,7 +84,6 @@ GEM
       modsulator (~> 0.0.7)
       net-sftp (~> 2.1)
       nokogiri (~> 1.6)
-      nokogiri-pretty (~> 0.1)
       om (~> 3.0)
       rdf (~> 1.1.7)
       rest-client (~> 1.7)
@@ -97,7 +96,7 @@ GEM
       stanford-mods (= 1.5.3)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-workflow-service (2.0.0)
+    dor-workflow-service (2.0.1)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
       faraday (~> 0.9.2)
@@ -120,7 +119,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    iso-639 (0.2.5)
+    iso-639 (0.2.8)
     json (1.8.3)
     link_header (0.0.8)
     lyber-core (4.0.3)
@@ -133,9 +132,9 @@ GEM
       validatable
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_exiftool (2.5.1)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     moab-versioning (2.0.0)
       confstruct
       json
@@ -152,21 +151,20 @@ GEM
       nokogiri
       roo (>= 1.1)
     mono_logger (1.1.0)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
+    net-ssh (3.2.0)
     netrc (0.11.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
-    nokogiri-pretty (0.1.0)
-      nokogiri
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
@@ -178,6 +176,7 @@ GEM
       mediashelf-loggable
       nokogiri (>= 1.4.2)
       solrizer (~> 3.1.0)
+    pkg-config (1.1.7)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -278,7 +277,7 @@ GEM
       nokogiri
       stomp
       xml-simple
-    spreadsheet (1.1.1)
+    spreadsheet (1.1.2)
       ruby-ole (>= 1.0)
     sshkit (1.8.1)
       net-scp (>= 1.1.2)
@@ -287,7 +286,7 @@ GEM
       activesupport
       mods (~> 2.0.2)
     state_machine (1.2.0)
-    stomp (1.3.4)
+    stomp (1.4.1)
     systemu (2.6.5)
     thor (0.19.1)
     tilt (2.0.2)
@@ -313,7 +312,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rvm
   dlss-capistrano
-  dor-services (~> 5.4, >= 5.4.2)
+  dor-services (~> 5.8, >= 5.8.2)
   fastimage (~> 1.7)
   ffi-geos (~> 1.0)
   lyber-core (~> 4.0, >= 4.0.3)
@@ -330,4 +329,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
This PR upgrade dor-services to 5.8.2 to fix the `.save` problem with the Solr 6 upgrade. It was previously running on 5.4.2.