### PR TITLE
rollback net-http-persistent due to incompatibility with faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'slop', '~> 3.6'              # for bin/run_robot
 gem 'whenever', '~> 0.9'
 gem 'honeybadger'
 
+gem 'net-http-persistent', '~> 2.9.4' # TODO: https://github.com/drbrain/net-http-persistent/issues/80
+
 group :development do
   gem 'capistrano-bundler'
   gem 'capistrano-rvm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,6 @@ GEM
     chronic (0.10.2)
     coderay (1.1.1)
     confstruct (0.2.7)
-    connection_pool (2.2.1)
     daemons (1.2.3)
     dbf (3.1.0)
     deprecation (1.0.0)
@@ -160,8 +159,7 @@ GEM
     mono_logger (1.1.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    net-http-persistent (3.0.0)
-      connection_pool (~> 2.2)
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -326,6 +324,7 @@ DEPENDENCIES
   ffi-geos (~> 1.0)
   honeybadger
   lyber-core (~> 4.0, >= 4.0.3)
+  net-http-persistent (~> 2.9.4)
   pry (~> 0.10)
   rake (~> 10.3)
   redcarpet


### PR DESCRIPTION
@cbeer Interestingly enough, it didn't send a honeybadger notification :(

See https://github.com/drbrain/net-http-persistent/issues/80 for note on incompatibility

```
ERROR [2017-07-19 11:46:35] (6403)  :: Cannot set druid:hs625cr1878 to status='error'
wrong number of arguments (given 1, expected 0)
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/net-http-persistent-3.0.0/lib/net/http/persistent.rb:505
:in `initialize'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http_persistent.r
b:22:in `new'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http_persistent.r
b:22:in `net_http_connection'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http.rb:85:in `wi
th_net_http_connection'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http.rb:33:in `ca
ll'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/rack_builder.rb:139:in `build
_response'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/connection.rb:386:in `run_req
uest'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/faraday-0.12.1/lib/faraday/connection.rb:186:in `put'
/opt/app/lyberadmin/gis-robot-suite/shared/bundle/ruby/2.3.0/gems/dor-workflow-service-2.2.1/lib/dor/services/workflow_ser
vice.rb:565:in `send_workflow_resource_request'
```