### PR TITLE
fix for dc_creator_sm when only a single value but is really multivalued for schema

### DIFF
--- a/robots/gisDiscovery/export-opengeometadata.rb
+++ b/robots/gisDiscovery/export-opengeometadata.rb
@@ -115,6 +115,7 @@ module Robots       # Robot package
             v = v.to_f if k =~ /_(d|f)$/ # decimal
             if h[k].nil?
               h[k] = v # assign singleton
+              h[k] = [v].flatten if k =~ /_sm$/ # unless it's supposed to be an Array
             else
               unless h[k].is_a? Array
                 h[k] = [h[k]] # convert singleton into Array


### PR DESCRIPTION
This PR fixes #121. Sometimes there's only a single value for a multivalued field like `dc_creator_sm`, and the OpenGeoMetadata export does not handle that correctly (it has to convert from MODS to GeoBlacklight XML to GeoBlacklight JSON -- 🙄 ), so this PR fixes that bug.

For example, `dct_temporal_sm` is a single value -- https://raw.githubusercontent.com/OpenGeoMetadata/edu.stanford.purl/master/bc/641/kr/2427/geoblacklight.json


cc @mejackreed