### PR TITLE
Use geocombine for enhancement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rsolr', '~> 1.0'
 gem 'slop', '~> 3.6'              # for bin/run_robot
 gem 'whenever', '~> 0.9'
 gem 'honeybadger'
+gem 'geo_combine'
 
 gem 'net-http-persistent', '~> 2.9.4' # TODO: https://github.com/drbrain/net-http-persistent/issues/80
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     confstruct (0.2.7)
+    crass (1.0.3)
     daemons (1.2.6)
     dbf (3.1.1)
     deprecation (0.99.0)
@@ -124,6 +125,12 @@ GEM
     ffi (1.9.18)
     ffi-geos (1.2.1)
       ffi (>= 1.0.0)
+    geo_combine (0.3.1)
+      json-schema
+      nokogiri
+      rsolr
+      sanitize
+      thor
     haml (4.0.7)
       tilt
     honeybadger (3.2.0)
@@ -136,6 +143,8 @@ GEM
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.8)
     json (2.1.0)
+    json-schema (2.6.2)
+      addressable (~> 2.3.8)
     link_header (0.0.8)
     lyber-core (4.1.3)
       activesupport
@@ -183,6 +192,8 @@ GEM
       mini_portile2 (~> 2.3.0)
     nokogiri-happymapper (0.6.0)
       nokogiri (~> 1.5)
+    nokogumbo (1.4.13)
+      nokogiri
     nom-xml (0.6.0)
       activesupport (>= 3.2.18)
       i18n
@@ -281,6 +292,10 @@ GEM
       nokogiri
       rest-client
     rubyzip (1.2.1)
+    sanitize (4.5.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -337,6 +352,7 @@ DEPENDENCIES
   dor-services (~> 5.8, >= 5.8.2)
   fastimage (~> 1.7)
   ffi-geos (~> 1.0)
+  geo_combine
   honeybadger
   lyber-core (~> 4.0, >= 4.0.3)
   net-http-persistent (~> 2.9.4)

--- a/robots/gisDiscovery/export-opengeometadata.rb
+++ b/robots/gisDiscovery/export-opengeometadata.rb
@@ -101,28 +101,10 @@ module Robots       # Robot package
 
           # Export GeoBlacklight as JSON
           LyberCore::Log.debug "export-opengeometadata: #{druid} extracting GeoBlacklight"
-          ifn = File.join(stagedir, 'metadata', 'geoblacklight.xml')
+          ifn = File.join(stagedir, 'metadata', 'geoblacklight.json')
           fail "export-opengeometadata: #{druid} cannot find GeoBlacklight in #{ifn}" unless File.size?(ifn)
           ofn = File.join(exportdir, 'geoblacklight.json')
-          # convert XML into JSON
-          doc = Nokogiri::XML(File.read(ifn))
-          h = {}
-          doc.xpath('//xmlns:field').each do |node|
-            # for each field copy into hash, but if multiple values, copy into array
-            k = node['name'].to_s
-            v = node.content.to_s
-            v = v.to_i if k =~ /_(i|l)$/ # integer
-            v = v.to_f if k =~ /_(d|f)$/ # decimal
-            if h[k].nil?
-              h[k] = v # assign singleton
-            else
-              unless h[k].is_a? Array
-                h[k] = [h[k]] # convert singleton into Array
-              end
-              h[k] << v # add to array
-            end
-          end
-          File.open(ofn, 'wb') { |f| f << JSON.pretty_generate(h) }
+          FileUtils.cp(ifn, ofn)
         end
       end
     end

--- a/robots/gisDiscovery/finish-gis-discovery-workflow.rb
+++ b/robots/gisDiscovery/finish-gis-discovery-workflow.rb
@@ -16,15 +16,7 @@ module Robots       # Robot package
         #
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
-          druid = GisRobotSuite.initialize_robot druid
-          LyberCore::Log.debug "finish-gis-discovery-workflow working on #{druid}"
-
-          rootdir = GisRobotSuite.locate_druid_path druid, type: :stage
-
-          xmlfn = File.join(rootdir, 'metadata', 'geoblacklight.xml')
-          fail "finish-gis-discovery-workflow: #{druid} cannot locate GeoBlacklight metadata: #{xmlfn}" unless File.size?(xmlfn)
-
-          # XXX: check Solr index too
+          # noop
         end
       end
     end


### PR DESCRIPTION
This PR fixes #121, and fixes #123 by:

- `generate-geoblacklight` reorganized to generate a JSON version of GeoBlacklight record
- use `GeoCombine::Geoblacklight.enhance_metadata` on that JSON version
- `load-geoblacklight` use the `.json` version rather than the `.xml` to load into Solr
- `export-opengeometadata` just copies the `.json` file (XML conversion code moved to generate-geoblacklight)
- remove dead code in the final noop step robot

Tested in -dev environment.