### PR TITLE
Don't abuse NotImplementedError

### DIFF
--- a/lib/gis-robot-suite/utils.rb
+++ b/lib/gis-robot-suite/utils.rb
@@ -60,7 +60,7 @@ module GisRobotSuite
         fail "Unknown 3-band raster data type: #{info[:type]}"
       end
     else
-      fail NotImplementedError, "Unsupported number of bands: #{info[:nbands]}"
+      fail "Unsupported number of bands: #{info[:nbands]}"
     end
   end
 
@@ -82,7 +82,7 @@ module GisRobotSuite
     elsif opts[:type] == :workspace
       rootdir = DruidTools::Druid.new(druid, Dor::Config.geohydra.workspace).path
     else
-      fail NotImplementedError, 'Only :stage, :workspace are supported'
+      fail 'Only :stage, :workspace are supported'
     end
 
     fail "Missing #{rootdir}" if opts[:validate] && !File.directory?(rootdir)

--- a/robots/gisAssembly/approve-data.rb
+++ b/robots/gisAssembly/approve-data.rb
@@ -16,7 +16,7 @@ module Robots       # Robot package
         #
         # @param [String] _druid -- the Druid identifier for the object to process
         def perform(_druid)
-          fail NotImplementedError
+          fail 'not implemented'
         end
       end
     end

--- a/robots/gisAssembly/approve-metadata.rb
+++ b/robots/gisAssembly/approve-metadata.rb
@@ -16,7 +16,7 @@ module Robots       # Robot package
         #
         # @param [String] _druid -- the Druid identifier for the object to process
         def perform(_druid)
-          fail NotImplementedError
+          fail 'not implemented'
         end
       end
     end

--- a/robots/gisAssembly/normalize-data.rb
+++ b/robots/gisAssembly/normalize-data.rb
@@ -270,13 +270,13 @@ module Robots       # Robot package
               elsif filetype == 'ArcGRID'
                 reproject_arcgrid druid, fn, proj, flags
               else
-                fail NotImplementedError, "normalize-data: #{druid} has unsupported Raster file format: #{format}"
+                fail "normalize-data: #{druid} has unsupported Raster file format: #{format}"
               end
             else
               fail "normalize-data: #{druid} cannot locate filetype from MODS format: #{format}"
             end
           else
-            fail NotImplementedError, "normalize-data: #{druid} has unsupported file format: #{format}"
+            fail "normalize-data: #{druid} has unsupported file format: #{format}"
           end
         end
       end

--- a/robots/gisDelivery/load-geoserver.rb
+++ b/robots/gisDelivery/load-geoserver.rb
@@ -62,7 +62,7 @@ module Robots       # Robot package
           elsif layer['raster'] && layer['raster']['format'] == 'GeoTIFF'
             create_raster(catalog, ws, layer['raster'])
           else
-            fail NotImplementedError, "load-geoserver: #{druid} has unknown layer format: #{layer}"
+            fail "load-geoserver: #{druid} has unknown layer format: #{layer}"
           end
 
           # Reload the slave catalog

--- a/robots/gisDelivery/load-geowebcache.rb
+++ b/robots/gisDelivery/load-geowebcache.rb
@@ -18,7 +18,7 @@ module Robots       # Robot package
         def perform(druid)
           LyberCore::Log.debug "load-geowebcache working on #{druid}"
 
-          fail NotImplementedError # XXX: load to external geowebcache registry if needed
+          fail 'not implemented' # XXX: load to external geowebcache registry if needed
         end
       end
     end


### PR DESCRIPTION
The purpose of NotImplementedError from rubydocs is:
> NotImplementedError is raised when a feature is not implemented on the current platform. For  example, methods depending on the fsync or fork system calls may raise this exception if the underlying operating system or Ruby runtime does not support them.