### PR TITLE
Replace robot full_restart with hot_swap

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,4 +42,4 @@ set :bundle_without, %w[development deployment].join(' ')
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
 
-after 'deploy:publishing', 'resque:pool:full_restart'
+after 'deploy:publishing', 'resque:pool:hot_swap'


### PR DESCRIPTION
## Why was this change made?

To further unify deployments for robot suites with a single resque-pool



## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

A PR to DevOpsDocs is at https://github.com/sul-dlss/DevOpsDocs/pull/335