### PR TITLE
Fix deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,7 +27,7 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 set :linked_files, %w(config/honeybadger.yml)
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w(log run tmp/pids config/environments config/certs config/ArcGIS)
+set :linked_dirs, %w(log run tmp/pids config/environments config/certs config/settings config/ArcGIS)
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,4 +28,4 @@ purl:
   url: 'http://localhost/purl'
 
 stacks:
-  url: 'https://stacks.stanford.edu'
+  url: 'https://stacks.example.org'


### PR DESCRIPTION
## Why was this change made?

gis-robots were busted in production  (and in stage, no doubt) - this fixed them. 

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a