### PR TITLE
Use the settings for the stacks url

### DIFF
--- a/robots/gisDiscovery/generate-geoblacklight.rb
+++ b/robots/gisDiscovery/generate-geoblacklight.rb
@@ -134,7 +134,7 @@ module Robots       # Robot package
           return unless doc.search('//file[@id=\'index_map.json\']').length > 0
 
           refs = JSON.parse(layer.metadata['dct_references_s'])
-          refs['https://openindexmaps.org'] = "#{Dor::Config.stacks.url}/file/druid:#{druid}/index_map.json"
+          refs['https://openindexmaps.org'] = "#{Settings.stacks.url}/file/druid:#{druid}/index_map.json"
           layer.metadata['dct_references_s'] = refs.to_json
         end
       end


### PR DESCRIPTION

## Why was this change made?
This is no longer part of Dor::Services.config.
See https://github.com/sul-dlss/gis-robot-suite/pull/236
Fixes #252



## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a