### PR TITLE
Fix load-geo-metadata robot in gisAssemblyWF

### DIFF
--- a/robots/gisAssembly/load-geo-metadata.rb
+++ b/robots/gisAssembly/load-geo-metadata.rb
@@ -24,7 +24,7 @@ module Robots       # Robot package
           current_tags = tags_client(item.pid).list
           return if current_tags.include?(TAG_GIS)
 
-          tags_client.create(tags: [TAG_GIS])
+          tags_client(item.pid).create(tags: [TAG_GIS])
         end
 
         # `perform` is the main entry point for the robot. This is where

--- a/spec/unit/gisAssembly/load_geo_metadata_spec.rb
+++ b/spec/unit/gisAssembly/load_geo_metadata_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::LoadGeoMetadata do
       allow(File).to receive(:size?).and_return(100)
       allow(Dor::Item).to receive(:find).and_return(item)
       allow(File).to receive(:read).and_return(xml)
-      allow(robot).to receive(:tags_client).and_return(fake_tags_client)
+      allow(robot).to receive(:tags_client).with(item.pid).and_return(fake_tags_client)
     end
 
     it 'tags the object' do


### PR DESCRIPTION
## Why was this change made?

Fixes #266

The test setup hid the underlying error.



## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no


## Does this change affect how this application integrates with other services?
Yes, it should restore the connection to DSA.
