### PR TITLE
Restore test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ config/certs
 .ruby-version
 .ruby-gemset
 run
-config/environments
+config/environments/*production*
+config/environments/*staging*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://travis-ci.org/sul-dlss/gis-robot-suite.svg?branch=master)](https://travis-ci.org/sul-dlss/gis-robot-suite)
 [![Coverage Status](https://coveralls.io/repos/github/sul-dlss/gis-robot-suite/badge.svg)](https://coveralls.io/github/sul-dlss/gis-robot-suite)
-
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fgis-robot-suite.svg)](https://badge.fury.io/gh/sul-dlss%2Fgis-robot-suite)
 
 GIS-Robot-Suite

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -29,11 +29,6 @@ LyberCore::Log.set_level(ROBOT_LOG.level)
 Dir["#{ROBOT_ROOT}/lib/*.rb"].each { |f| require f }
 require 'robots'
 
-# Load local environment configuration
-env_file = File.expand_path(File.dirname(__FILE__) + "/./environments/#{environment}")
-puts "Loading config from #{env_file}"
-require env_file
-
 Config.setup do |config|
   # Name of the constant exposing loaded settings
   config.const_name = 'Settings'
@@ -55,6 +50,11 @@ end
 Config.load_and_set_settings(
   Config.setting_files(File.expand_path(__dir__), environment)
 )
+
+# Load local environment configuration
+env_file = File.expand_path(File.dirname(__FILE__) + "/./environments/#{environment}")
+puts "Loading config from #{env_file}"
+require env_file
 
 module GisRobotSuite
   def self.connect_dor_services_app

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,0 +1,1 @@
+REDIS_URL = Settings.redis.url

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+redis:
+  url: 'localhost:6379/resque:test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,18 @@
 # Make sure specs run with the definitions from local.rb
-ENV['ROBOT_ENVIRONMENT'] ||= 'local'
+ENV['ROBOT_ENVIRONMENT'] ||= 'test'
+
+require 'coveralls'
+require 'simplecov'
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  track_files 'bin/**/*'
+  track_files 'lib/**/*.rb'
+  track_files 'robots/**/*.rb'
+  add_filter '/spec/'
+end
+Coveralls.wear!
 
 require_relative '../config/boot'
 
 require 'pry'
 require 'rspec'
-
-require 'coveralls'
-Coveralls.wear!
-require 'simplecov'
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-  add_filter 'spec'
-end


### PR DESCRIPTION
Connects to #186
Connects to #268

Required some setup of the test environment, which should not interfere with deployments (which are in production and staging envs).

## Why was this change made?

Because test coverage is currently showing at 0% but it's slightly higher than zero.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

Yes, tweaked the badges a bit.

## Does this change affect how this application integrates with other services?

No, should not.
