### PR TITLE
Remove settings for the outdated rvm/capistrano plugin

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,3 @@
-set :rvm_type, :system
-set :rvm_ruby_string, 'ruby-2.2.2'
-
 set :application, 'gisRobotSuite'
 set :repo_url, 'https://github.com/sul-dlss/gis-robot-suite.git'
 


### PR DESCRIPTION


## Why was this change made?

we use the capistrano/rvm gem now

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no

## Does this change affect how this application integrates with other services?
n
