### PR TITLE
Enable bundler2 style config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,6 +39,9 @@ set :honeybadger_env, fetch(:stage)
 
 set :bundle_without, %w[development deployment].join(' ')
 
+# Enable bundle2 style config
+set :bundler2_config_use_hook, true # this is how to opt-in to bundler 2-style config. it's false by default
+
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
 


### PR DESCRIPTION
## Why was this change made?

This allows us to `SKIP_BUNDLE_AUDIT=true cap deploy` in order to deploy with some of the older dependencies that are not passing audit. Discussion of how to handle those dependencies is ongoing.

## How was this change tested?

Manually deployed to stage

## Which documentation and/or configurations were updated?



