### PR TITLE
Link the geoserver files from shared configs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,7 +21,7 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 
 # Default value for :linked_files is []
 # set :linked_files, %w{config/database.yml}
-set :linked_files, %w(config/honeybadger.yml)
+set :linked_files, %w(config/honeybadger.yml config/rgeoserver_public.yml config/rgeoserver_restricted.yml)
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w(log run tmp/pids config/certs config/settings config/ArcGIS)


### PR DESCRIPTION
## Why was this change made?

They weren't getting linked.


## How was this change tested?

Deployed on prod and tested manually

## Which documentation and/or configurations were updated?
n/a


