### PR TITLE
Use the correct path to the rgeoserver_config

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -48,6 +48,8 @@ env_file = File.expand_path(File.dirname(__FILE__) + "/./environments/#{environm
 puts "Loading config from #{env_file}"
 require env_file
 
+ENV['RGEOSERVER_CONFIG'] ||= File.expand_path('rgeoserver.yml', __dir__)
+
 module GisRobotSuite
   def self.connect_dor_services_app
     Dor::Services::Client.configure(url: Settings.dor_services.url,

--- a/config/environments/example.rb
+++ b/config/environments/example.rb
@@ -21,5 +21,3 @@ ENV['PGDATABASE'] ||= 'example_db'
 ENV['PGHOST'] ||= 'localhost'
 ENV['PGPORT'] ||= '5432'
 ENV['PGUSER'] ||= 'example_user'
-
-ENV['RGEOSERVER_CONFIG'] ||= File.expand_path(File.join(File.dirname(__FILE__), ENV['ROBOT_ENVIRONMENT'] + '_rgeoserver.yml'))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,6 +20,4 @@ ENV['PGHOST'] ||= Settings.db.host
 ENV['PGPORT'] ||= Settings.db.port
 ENV['PGUSER'] ||= Settings.db.user
 
-ENV['RGEOSERVER_CONFIG'] ||= File.expand_path(File.join(File.dirname(__FILE__), "rgeoserver.yml"))
-
 ENV['ROBOT_DELAY'] = '0'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -20,6 +20,4 @@ ENV['PGHOST'] ||= Settings.db.host
 ENV['PGPORT'] ||= Settings.db.port
 ENV['PGUSER'] ||= Settings.db.user
 
-ENV['RGEOSERVER_CONFIG'] ||= File.expand_path(File.join(File.dirname(__FILE__), "rgeoserver.yml"))
-
 ENV['ROBOT_DELAY'] = '0'


### PR DESCRIPTION
## Why was this change made?
Fixes https://github.com/sul-dlss/gis-robot-suite/issues/316


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
`config/environments/*.rb` had the path removed because we can just set it once in config/boot.rb


