### PR TITLE
Make the gdal path configurable

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,3 +29,5 @@ purl:
 
 stacks:
   url: 'https://stacks.example.org'
+
+gdal_path: ''

--- a/lib/gis_robot_suite.rb
+++ b/lib/gis_robot_suite.rb
@@ -10,7 +10,7 @@ module GisRobotSuite
   # @return grayscale4, grayscale8, grayscale_N_M, rgb8, rgb16, rgb32
   def self.determine_raster_style(tifffn)
     # execute gdalinfo command
-    cmd = "gdalinfo -stats -norat -noct -nomd '#{tifffn}'"
+    cmd = "#{Settings.gdal_path}gdalinfo -stats -norat -noct -nomd '#{tifffn}'"
     infotxt = IO.popen(cmd) do |f|
       f.readlines
     end

--- a/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
@@ -32,7 +32,7 @@ module Robots       # Robot package
         # @return [Array#Float] ulx uly lrx lry
         def extent_shapefile(shpfn)
           LyberCore::Log.debug "extract-boundingbox: working on Shapefile: #{shpfn}"
-          IO.popen("ogrinfo -ro -so -al '#{shpfn}'") do |f|
+          IO.popen("#{Settings.gdal_path}ogrinfo -ro -so -al '#{shpfn}'") do |f|
             f.readlines.each do |line|
               # Extent: (-151.479444, 26.071745) - (-78.085007, 69.432500) --> (W, S) - (E, N)
               if line =~ /^Extent:\s+\((.*),\s*(.*)\)\s+-\s+\((.*),\s*(.*)\)/
@@ -52,7 +52,7 @@ module Robots       # Robot package
         # @return [Array#Float] ulx uly lrx lry
         def extent_geotiff(tiffn)
           LyberCore::Log.debug "extract-boundingbox: working on GeoTIFF: #{tiffn}"
-          IO.popen("gdalinfo '#{tiffn}'") do |f|
+          IO.popen("#{Settings.gdal_path}gdalinfo '#{tiffn}'") do |f|
             ulx = 0
             uly = 0
             lrx = 0

--- a/lib/robots/dor_repo/gis_assembly/generate_mods.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_mods.rb
@@ -15,7 +15,7 @@ module Robots       # Robot package
         #
         # @return [String] Point, Polygon, LineString as appropriate
         def geometry_type_ogrinfo(shp_filename)
-          IO.popen("ogrinfo -ro -so -al '#{shp_filename}'") do |f|
+          IO.popen("#{Settings.gdal_path}ogrinfo -ro -so -al '#{shp_filename}'") do |f|
             f.readlines.each do |line|
               if line =~ /^Geometry:\s+(.*)\s*$/
                 LyberCore::Log.debug "generate-mods: parsing ogrinfo geometry output: #{line}"


### PR DESCRIPTION
## Why was this change made?
With the centos 7 upgrade we can't expect the robots to have the gdal commands available on the path. This allows us to specify the location of this library.

## How was this change tested?
Deployed onto kurma-robots1-stage and tested.


## Which documentation and/or configurations were updated?
Needed shared configs here: https://github.com/sul-dlss/shared_configs/pull/1416 and prod will need that when upgraded to centos7


