### PR TITLE
Remove Dor::Config

### DIFF
--- a/config/environments/example.rb
+++ b/config/environments/example.rb
@@ -1,21 +1,5 @@
 # frozen_string_literal: true
 
-cert_dir = File.join(File.dirname(__FILE__), '..', 'certs')
-
-Dor::Config.configure do
-  fedora do
-    url 'https://localhost/fedora'
-  end
-
-  ssl do
-    cert_file File.join(cert_dir, 'example.crt')
-    key_file File.join(cert_dir, 'example.key')
-    key_pass ''
-  end
-
-  solrizer.url 'https://localhost/solr/solrizer'
-end
-
 REDIS_URL = 'localhost:6379/resque:development'
 
 # These are necessary for the gisDelivery/load-vector step which uses psql and shp2pgsql

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,19 +1,5 @@
 # frozen_string_literal: true
 
-Dor::Config.configure do
-  fedora do
-    url Settings.fedora.url
-  end
-
-  ssl do
-    cert_file Settings.ssl.cert_file
-    key_file Settings.ssl.key_file
-    key_pass Settings.ssl.key_pass
-  end
-
-  solr.url Settings.solr.url
-end
-
 REDIS_URL = Settings.redis.url
 
 # These are necessary for the gisDelivery/load-vector step which uses psql and shp2pgsql

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,19 +1,5 @@
 # frozen_string_literal: true
 
-Dor::Config.configure do
-  fedora do
-    url Settings.fedora.url
-  end
-
-  ssl do
-    cert_file Settings.ssl.cert_file
-    key_file Settings.ssl.key_file
-    key_pass Settings.ssl.key_pass
-  end
-
-  solr.url Settings.solr.url
-end
-
 REDIS_URL = Settings.redis.url
 
 # These are necessary for the gisDelivery/load-vector step which uses psql and shp2pgsql


### PR DESCRIPTION

## Why was this change made?

Because dor-services gem was removed in https://github.com/sul-dlss/gis-robot-suite/commit/539a778694faf8e7aedb8cedd46b0e4ecac1e34f


## How was this change tested?

test suite

## Which documentation and/or configurations were updated?

n/a

