### PR TITLE
Updated to use the correct constant from assembly-objectfile, removed…

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/generate_content_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_content_metadata.rb
@@ -13,9 +13,8 @@ module Robots       # Robot package
           super('gisAssemblyWF', 'generate-content-metadata', check_queued_status: true) # init LyberCore::Robot
         end
 
-        FILE_ATTRIBUTES = Assembly::FILE_ATTRIBUTES.merge(
-          'image/png' => Assembly::FILE_ATTRIBUTES['image/jp2'], # preview image
-          'application/zip' => Assembly::FILE_ATTRIBUTES['default'] # data file
+        FILE_ATTRIBUTES = ContentMetadata::File::ATTRIBUTES_FOR_TYPE.merge(
+          'image/png' => ContentMetadata::File::ATTRIBUTES_FOR_TYPE['image/jp2'] # preview image
         )
 
         # @param [String] druid


### PR DESCRIPTION
… redundancy.

## Why was this change made?
Fixes #345 

Assembly Object file gem changed location of a constant.  Removed  `'application/zip' => Assembly::FILE_ATTRIBUTES['default'] ` as both `application/zip` and `default` are the same. 


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
n/a


