### PR TITLE
Use dlss-capistrano to manage resque-pool

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -27,7 +27,7 @@ require 'capistrano/bundler'
 # require 'capistrano/rails/migrations'
 require 'capistrano/honeybadger'
 require 'dlss/capistrano'
-require 'capistrano-resque-pool'
+require 'dlss/capistrano/resque_pool'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :deployment do
   gem 'capistrano'
   gem 'capistrano-rvm'
   gem 'capistrano-bundler'
-  gem 'capistrano-resque-pool'
   gem 'dlss-capistrano'
   gem 'capistrano-shared_configs'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,9 +36,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-resque-pool (0.2.0)
-      capistrano
-      resque-pool
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
@@ -71,7 +68,7 @@ GEM
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.4.4)
-    dlss-capistrano (3.9.0)
+    dlss-capistrano (3.10.1)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -315,7 +312,6 @@ DEPENDENCIES
   assembly-objectfile
   capistrano
   capistrano-bundler
-  capistrano-resque-pool
   capistrano-rvm
   capistrano-shared_configs
   config (~> 2.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 
 # Default value for :linked_files is []
 # set :linked_files, %w{config/database.yml}
-set :linked_files, %w(config/honeybadger.yml config/rgeoserver.yml config/rgeoserver_public.yml config/rgeoserver_restricted.yml)
+set :linked_files, %w(config/honeybadger.yml config/rgeoserver.yml config/rgeoserver_public.yml config/rgeoserver_restricted.yml tmp/resque-pool.lock)
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w(log run tmp/pids config/certs config/settings config/ArcGIS)
@@ -43,5 +43,3 @@ set :bundler2_config_use_hook, true # this is how to opt-in to bundler 2-style c
 
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
-
-after 'deploy:publishing', 'resque:pool:hot_swap'


### PR DESCRIPTION
This replaces capistrano-resque-pool and works as expected with a hot-swappable pool.

Also includes:

Store resque-pool lockfile in shared dir
This allows the resque:pool:hot_swap capistrano task to do what we expect it to do.


