### PR TITLE
Remove legacy rgeoserver linked configs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,8 +22,7 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 # set :pty, true
 
 # Default value for :linked_files is []
-# set :linked_files, %w[config/database.yml]
-set :linked_files, %w[config/honeybadger.yml config/rgeoserver.yml config/rgeoserver_public.yml config/rgeoserver_restricted.yml tmp/resque-pool.lock]
+set :linked_files, %w[config/honeybadger.yml tmp/resque-pool.lock]
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w[log run tmp/pids config/certs config/settings config/ArcGIS]


### PR DESCRIPTION
## Why was this change made?
Removing legacy linked files, previous work moved this to a more "shared configs" based config #333
