### PR TITLE
QA should see itself as production

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -4,5 +4,5 @@ server 'kurma-robots1-qa.stanford.edu', user: 'lyberadmin', roles: %w[web app db
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
-set :deploy_environment, 'qa'
+set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)


### PR DESCRIPTION
## Why was this change made?

robots resque-pool and robot console weren't usable on the QA instance of gis-robot-suite

## How was this change tested?

we'll deploy to QA to test

## Which documentation and/or configurations were updated?

just the QA deploy config