### PR TITLE
Remove dlss-capistrano provided bundler2 config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,8 +37,5 @@ set :honeybadger_env, fetch(:stage)
 
 set :bundle_without, %w[development deployment].join(' ')
 
-# Enable bundle2 style config
-set :bundler2_config_use_hook, true # this is how to opt-in to bundler 2-style config. it's false by default
-
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'


### PR DESCRIPTION


## Why was this change made?

This functionality is now handled by capistrano-bundler 2.0

## How was this change tested?



## Which documentation and/or configurations were updated?



