### PR TITLE
Remove unused settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,9 +27,6 @@ geohydra:
 purl:
   url: 'http://localhost/purl'
 
-stacks:
-  url: 'https://stacks.example.org'
-
 gdal_path: ''
 
 geoserver:


### PR DESCRIPTION

## Why was this change made?

No longer needed since gisDiscoveryWF was removed. https://github.com/sul-dlss/gis-robot-suite/commit/02185f4563f4e47b9b1f763513040c9225661883#diff-ed29dc27cd08d28e4f9902ec125190bd7e8ec2548d1601b4c899a0779b06ac5b


## How was this change tested?



## Which documentation and/or configurations were updated?



