### PR TITLE
Remove unused config variables

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,17 +18,11 @@ geohydra:
     dir: '/geotiff'
   postgis:
     schema: 'druid'
-  solr:
-    url: 'https://localhost/solr'
-    collection: 'example'
   opengeometadata:
     dir: '/opengeometadata'
 
 purl:
   url: 'http://localhost/purl'
-
-stacks:
-  url: 'https://stacks.example.org'
 
 gdal_path: ''
 


### PR DESCRIPTION
## Why was this change made?

No longer needed since gisDiscoveryWF was removed. 02185f4#diff-ed29dc27cd08d28e4f9902ec125190bd7e8ec2548d1601b4c899a0779b06ac5b

## How was this change tested?



## Which documentation and/or configurations were updated?



