### PR TITLE
Set the geo type when attaching geo metadata

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/load_geo_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/load_geo_metadata.rb
@@ -32,7 +32,10 @@ module Robots
 
           client = Dor::Services::Client.object(druid)
           cocina = client.find
-          updated = cocina.new(geographic: { iso19139: File.read(fn) })
+          updated = cocina.new(
+            type: Cocina::Models::Vocab.geo,
+            geographic: { iso19139: File.read(fn) }
+          )
           # Load geoMetadata into DOR
           client.update(params: updated)
 


### PR DESCRIPTION
## Why was this change made?
It's confusing to have non-geo objects with geo metadata.



## How was this change tested?



## Which documentation and/or configurations were updated?



