### PR TITLE
Update QA deploy server

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'kurma-robots1-qa.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
+server 'kurma-robots-qa-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
The new server name is kurma-robots-qa-01

## Why was this change made?

New kurma QA db and robot servers were built, with new server names (kurma-db-qa-01,kurma-db-qa-02,kurma-robots-qa-01)

## How was this change tested?

cap deploy

## Which documentation and/or configurations were updated?

DevOpsDocs PR put in to include QA servers

