### PR TITLE
fix issue with hanging resque pool on qa

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,6 +2,9 @@
 
 server 'kurma-robots-qa-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
 
+# for ubuntu to perform resque:pool:hot_swap
+set :pty, true
+
 Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'production'


### PR DESCRIPTION
## Why was this change made?

Hot swapping resque pool hangs in QA due to the OS.  Apply same fix as was needed for preservation catalog: https://github.com/sul-dlss/preservation_catalog/blob/main/config/deploy/prod.rb#L9-10

## How was this change tested?

Testing command on QA

## Which documentation and/or configurations were updated?



