### PR TITLE
update hostname for new stage box

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'kurma-robots1-stage.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
+server 'kurma-robots-stage-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
## Why was this change made? 🤔

the old hostname no longer resolves, now that the box has been rebuilt on ubuntu and given a hostname that follows our current conventions.

## How was this change tested? 🤨

i was able to `bundle exec cap stage ssh` successfully, whereas i'd get a connection error before this fix.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


