### PR TITLE
cap terminal setting for ubuntu so that terminal session doesn't mysteriously hang when running resque-pool hotswap, see also e.g. pres cat prod

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,6 +2,9 @@
 
 server 'kurma-robots-stage-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
 
+# for ubuntu to perform resque:pool:hot_swap
+set :pty, true
+
 Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'staging'


### PR DESCRIPTION
## Why was this change made? 🤔

deployment hung on resque-pool hotswap.  this change fixed that problem for other ubuntu deployments, e.g.:
https://github.com/sul-dlss/preservation_catalog/blob/4f23bdf56a391fd59c05e86389d4c13cb77a9967/config/deploy/prod.rb#L9-L10

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


