### PR TITLE
Enforce ruby 3.0.3 at deploy and bundle time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ruby '3.0.3'
+
 source 'https://rubygems.org'
 
 gem 'assembly-objectfile'
@@ -42,6 +44,6 @@ group :deployment do
   gem 'capistrano'
   gem 'capistrano-rvm'
   gem 'capistrano-bundler'
-  gem 'dlss-capistrano', require: false
+  gem 'dlss-capistrano', require: false, github: 'sul-dlss/dlss-capistrano', branch: 'ruby-version-reporting'
   gem 'capistrano-shared_configs'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/sul-dlss/dlss-capistrano.git
+  revision: 6104bb256d4f5881db73259be11449bd69eb5a13
+  branch: ruby-version-reporting
+  specs:
+    dlss-capistrano (4.1.1)
+      capistrano (~> 3.0)
+      capistrano-bundle_audit (>= 0.3.0)
+      capistrano-one_time_key
+      capistrano-rvm
+      capistrano-shared_configs
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,11 +78,6 @@ GEM
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.5.0)
-    dlss-capistrano (4.1.1)
-      capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.3.0)
-      capistrano-one_time_key
-      capistrano-shared_configs
     docile (1.4.0)
     dor-services-client (11.0.0)
       activesupport (>= 4.2, < 8)
@@ -297,7 +304,7 @@ DEPENDENCIES
   capistrano-rvm
   capistrano-shared_configs
   config (~> 3.1)
-  dlss-capistrano
+  dlss-capistrano!
   dor-services-client (~> 11.0)
   dor-workflow-client (~> 4.0)
   druid-tools
@@ -323,6 +330,9 @@ DEPENDENCIES
   stanford-mods
   webmock
   zeitwerk (~> 2.1)
+
+RUBY VERSION
+   ruby 3.0.3p157
 
 BUNDLED WITH
    2.3.9

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -39,3 +39,6 @@ set :bundle_without, %w[development deployment].join(' ')
 
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
+
+# Prevent deployment if application ruby not installed
+set :validate_ruby_on_deploy, true


### PR DESCRIPTION
## Why was this change made? 🤔

To make it clearer what version of Ruby is required, and to make sure that version of Ruby is installed on servers before deploying.

## How was this change tested? 🤨

Tested by deploying to QA
