### PR TITLE
remove references to Fedora and Datastream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,10 +85,6 @@ Naming/FileName:
     - Capfile
     - Gemfile
 
-Naming/MethodName:
-  Exclude:
-    - lib/robots/dor_repo/gis_assembly/generate_geo_metadata.rb # to_geoMetadataDS
-
 # --- Performance ---
 
 # --- RSpec ---

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to start all robots defined in `config/resque-pool.yml`.
 * `approve-metadata` :: Approve metadata quality and release for workflow (manual step)
 * `extract-thumbnail` :: Extract thumbnail preview from ArcCatalog metadata
 * `extract-iso19139` :: Transform ISO 19139 metadata from ArcCatalog metadata
-* `generate-geo-metadata` :: Convert ISO 19139 metadata into geoMetadata datastream
+* `generate-geo-metadata` :: Convert ISO 19139 metadata into geoMetadata RDF XML file
 * `generate-mods` :: Convert geoMetadata into MODS
 * `assign-placenames` :: Insert linked data into MODS record from gazetteer
 * `finish-metadata` :: Finalize the metadata preparation (validity check)
@@ -40,7 +40,7 @@ to start all robots defined in `config/resque-pool.yml`.
 * `extract-boundingbox` :: Extract bounding box from data for MODS record
 * `finish-data` :: Finalize the data preparation (validity check)
 * `generate-content-metadata` :: Generate contentMetadata manifest
-* `load-geo-metadata` :: Accession geoMetadata datastream into DOR repository
+* `load-geo-metadata` :: Accession geoMetadata xml into SDR
 * `finish-gis-assembly-workflow` :: Finalize assembly workflow to prepare for assembly/delivery/discovery (validity check)
 * `start-assembly-workflow` :: Kickstart the core assembly workflow at assemblyWF (manual step)
 * `start-delivery-workflow` :: Kickstart the GIS delivery workflow at gisDeliveryWF (manual step)

--- a/lib/robots/dor_repo/gis_assembly/generate_mods.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_mods.rb
@@ -121,7 +121,7 @@ module Robots
           raise "generate-mods: #{druid} cannot locate #{fn}" unless File.size?(fn)
 
           # parse geometadata as input to MODS transform
-          geoMetadataDS = Nokogiri::XML(File.read(fn))
+          geo_metadata_rdf_xml = Nokogiri::XML(File.read(fn))
 
           # detect fileFormat and geometryType
           fn = Dir.glob("#{rootdir}/temp/*.shp").first
@@ -147,13 +147,13 @@ module Robots
           # load PURL
           purl = Settings.purl.url + "/#{druid.gsub(/^druid:/, '')}"
 
-          # XXX: clean up dor-services geoMetadataDS to not generate transforms
+          # clean up geo_metadata_rdf_xml to not generate transforms
           modsFn = File.join(rootdir, 'metadata', 'descMetadata.xml')
           File.open(modsFn, 'wb') do |f|
 
-            f << to_mods(geoMetadataDS, geometryType: geometryType,
-                                        fileFormat: fileFormat,
-                                        purl: purl).to_xml(index: 2)
+            f << to_mods(geo_metadata_rdf_xml, geometryType: geometryType,
+                                            fileFormat: fileFormat,
+                                            purl: purl).to_xml(index: 2)
           rescue ArgumentError => e
             raise "generate-mods: #{druid} cannot process MODS: #{e}"
 

--- a/lib/robots/dor_repo/gis_assembly/generate_mods.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_mods.rb
@@ -10,6 +10,69 @@ module Robots
           super('gisAssemblyWF', 'generate-mods', check_queued_status: true) # init LyberCore::Robot
         end
 
+        # `perform` is the main entry point for the robot. This is where
+        # all of the robot's work is done.
+        #
+        # @param [String] druid -- the Druid identifier for the object to process
+        def perform(druid)
+          druid = druid.delete_prefix('druid:')
+          LyberCore::Log.debug "generate-mods working on #{druid}"
+
+          rootdir = GisRobotSuite.locate_druid_path druid, type: :stage
+
+          # short-circuit if already have MODS file
+          desc_metadata = File.join(rootdir, 'metadata', 'descMetadata.xml')
+          if File.size?(desc_metadata)
+            LyberCore::Log.info "generate-mods: #{druid} found existing #{desc_metadata}"
+            return
+          end
+
+          geo_metadata_file = File.join(rootdir, 'metadata', 'geoMetadata.xml')
+          raise "generate-mods: #{druid} cannot locate #{geo_metadata_file}" unless File.size?(geo_metadata_file)
+
+          # parse geometadata as input to MODS transform
+          geo_metadata_rdf_xml = Nokogiri::XML(File.read(geo_metadata_file))
+
+          # detect fileFormat and geometryType
+          shp_file = Dir.glob("#{rootdir}/temp/*.shp").first
+          if shp_file.nil?
+            geometryType = 'Raster'
+            tif_file = Dir.glob("#{rootdir}/temp/*.tif").first
+            if tif_file.nil?
+              metadata_xml_file = Dir.glob("#{rootdir}/temp/*/metadata.xml").first
+              if metadata_xml_file.nil?
+                raise "generate-mods: #{druid} cannot detect fileFormat: #{rootdir}/temp"
+              else
+                fileFormat = 'ArcGRID'
+              end
+            else
+              fileFormat = 'GeoTIFF'
+            end
+          else
+            geometryType = geometry_type_ogrinfo(shp_file)
+            geometryType = 'LineString' if geometryType =~ /^Line/
+            fileFormat = 'Shapefile'
+          end
+
+          # load PURL
+          purl = Settings.purl.url + "/#{druid.gsub(/^druid:/, '')}"
+
+          # clean up geo_metadata_rdf_xml to not generate transforms
+          mods_xml_file = File.join(rootdir, 'metadata', 'descMetadata.xml')
+          File.open(mods_xml_file, 'wb') do |file_content|
+            file_content << to_mods(geo_metadata_rdf_xml,
+                                    geometryType: geometryType,
+                                    fileFormat: fileFormat,
+                                    purl: purl).to_xml(index: 2)
+          rescue ArgumentError => e
+            raise "generate-mods: #{druid} cannot process MODS: #{e}"
+          end
+
+          raise "generate-mods: #{druid} did not write MODS correctly" unless File.size?(mods_xml_file)
+        end
+
+        private
+
         # Reads the shapefile to determine geometry type
         #
         # @return [String] Point, Polygon, LineString as appropriate
@@ -98,67 +161,6 @@ module Robots
             e.content = "(#{to_coordinates_ddmmss(e.content.to_s)})"
           end
           doc
-        end
-
-        # `perform` is the main entry point for the robot. This is where
-        # all of the robot's work is done.
-        #
-        # @param [String] druid -- the Druid identifier for the object to process
-        def perform(druid)
-          druid = druid.delete_prefix('druid:')
-          LyberCore::Log.debug "generate-mods working on #{druid}"
-
-          rootdir = GisRobotSuite.locate_druid_path druid, type: :stage
-
-          # short-circuit if already have MODS file
-          fn = File.join(rootdir, 'metadata', 'descMetadata.xml')
-          if File.size?(fn)
-            LyberCore::Log.info "generate-mods: #{druid} found existing #{fn}"
-            return
-          end
-
-          fn = File.join(rootdir, 'metadata', 'geoMetadata.xml')
-          raise "generate-mods: #{druid} cannot locate #{fn}" unless File.size?(fn)
-
-          # parse geometadata as input to MODS transform
-          geo_metadata_rdf_xml = Nokogiri::XML(File.read(fn))
-
-          # detect fileFormat and geometryType
-          fn = Dir.glob("#{rootdir}/temp/*.shp").first
-          if fn.nil?
-            geometryType = 'Raster'
-            fn = Dir.glob("#{rootdir}/temp/*.tif").first
-            if fn.nil?
-              fn = Dir.glob("#{rootdir}/temp/*/metadata.xml").first
-              if fn.nil?
-                raise "generate-mods: #{druid} cannot detect fileFormat: #{rootdir}/temp"
-              else
-                fileFormat = 'ArcGRID'
-              end
-            else
-              fileFormat = 'GeoTIFF'
-            end
-          else
-            geometryType = geometry_type_ogrinfo(fn)
-            geometryType = 'LineString' if geometryType =~ /^Line/
-            fileFormat = 'Shapefile'
-          end
-
-          # load PURL
-          purl = Settings.purl.url + "/#{druid.gsub(/^druid:/, '')}"
-
-          # clean up geo_metadata_rdf_xml to not generate transforms
-          modsFn = File.join(rootdir, 'metadata', 'descMetadata.xml')
-          File.open(modsFn, 'wb') do |f|
-
-            f << to_mods(geo_metadata_rdf_xml, geometryType: geometryType,
-                                            fileFormat: fileFormat,
-                                            purl: purl).to_xml(index: 2)
-          rescue ArgumentError => e
-            raise "generate-mods: #{druid} cannot process MODS: #{e}"
-
-          end
-          raise "generate-mods: #{druid} did not write MODS correctly" unless File.size?(modsFn)
         end
       end
     end

--- a/lib/robots/dor_repo/gis_assembly/load_geo_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/load_geo_metadata.rb
@@ -26,7 +26,7 @@ module Robots
 
           rootdir = GisRobotSuite.locate_druid_path druid_without_namespace, type: :stage
 
-          # Locate geoMetadata datastream
+          # Locate geoMetadata xml file
           fn = File.join(rootdir, 'metadata', 'geoMetadata.xml')
           raise "load-geo-metadata: #{druid_without_namespace} cannot locate geoMetadata: #{fn}" unless File.size?(fn)
 

--- a/spec/robots/dor_repo/gis_assembly/generate_mods_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/generate_mods_spec.rb
@@ -10,17 +10,17 @@ RSpec.describe Robots::DorRepo::GisAssembly::GenerateMods do
   end
 
   it 'converts DD to DDMMSS' do
-    expect(subject.dd2ddmmss_abs('-109.758319')).to eq('109°45ʹ30ʺ')
-    expect(subject.dd2ddmmss_abs('48.999336')).to eq('48°59ʹ58ʺ')
+    expect(subject.send(:dd2ddmmss_abs, '-109.758319')).to eq('109°45ʹ30ʺ')
+    expect(subject.send(:dd2ddmmss_abs, '48.999336')).to eq('48°59ʹ58ʺ')
   end
 
   it 'converts MARC to DDMMSS' do
-    expect(subject.to_coordinates_ddmmss('-180 -- 180/90 -- -90')).to eq('W 180°--E 180°/N 90°--S 90°')
-    expect(subject.to_coordinates_ddmmss('-109.758319 -- -88.990844/48.999336 -- 29.423028')).to eq('W 109°45ʹ30ʺ--W 88°59ʹ27ʺ/N 48°59ʹ58ʺ--N 29°25ʹ23ʺ')
+    expect(subject.send(:to_coordinates_ddmmss, '-180 -- 180/90 -- -90')).to eq('W 180°--E 180°/N 90°--S 90°')
+    expect(subject.send(:to_coordinates_ddmmss, '-109.758319 -- -88.990844/48.999336 -- 29.423028')).to eq('W 109°45ʹ30ʺ--W 88°59ʹ27ʺ/N 48°59ʹ58ʺ--N 29°25ʹ23ʺ')
   end
 
   it 'handles bad arguments' do
-    expect { subject.to_coordinates_ddmmss('-185 -- 185/95 -- -95') }.to raise_error(ArgumentError)
+    expect { subject.send(:to_coordinates_ddmmss, '-185 -- 185/95 -- -95') }.to raise_error(ArgumentError)
   end
 
   describe '#to_mods' do
@@ -28,7 +28,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::GenerateMods do
 
     it 'runs without error' do
       expect do
-        subject.to_mods(geo_metadata, { purl: 'https://purl.stanford.edu/ym947vs2726', newfoo: '123' })
+        subject.send(:to_mods, geo_metadata, { purl: 'https://purl.stanford.edu/ym947vs2726', newfoo: '123' })
       end.not_to raise_error
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Removed references to "datastream" which are no longer relevant, in a post Fedora 3 world.

**Ignore coverage drop** - look at the files;  no code was really changed, just comments and a method name.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


