### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -19,7 +19,6 @@ install_plugin Capistrano::SCM::Git
 #   https://github.com/capistrano/bundler
 #   https://github.com/capistrano/rails
 #
-require 'capistrano/rvm'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ end
 
 group :deployment do
   gem 'capistrano'
-  gem 'capistrano-rvm'
   gem 'capistrano-bundler'
   gem 'dlss-capistrano', require: false
   gem 'capistrano-shared_configs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,9 +33,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     cocina-models (0.84.4)
       activesupport
@@ -280,7 +277,6 @@ DEPENDENCIES
   assembly-objectfile
   capistrano
   capistrano-bundler
-  capistrano-rvm
   capistrano-shared_configs
   config (~> 3.1)
   dlss-capistrano


### PR DESCRIPTION
## Why was this change made? 🤔


This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.


## How was this change tested? 🤨

Deployed to stage
