### PR TITLE
cap deploy sets :pty to true for all deployed environments

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,7 +19,8 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 # set :log_level, :debug
 
 # Default value for :pty is false
-# set :pty, true
+# true for ubuntu to perform resque:pool:hot_swap
+set :pty, true
 
 # Default value for :linked_files is []
 set :linked_files, %w[config/honeybadger.yml tmp/resque-pool.lock]

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,9 +2,6 @@
 
 server 'kurma-robots-qa-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
 
-# for ubuntu to perform resque:pool:hot_swap
-set :pty, true
-
 Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,9 +2,6 @@
 
 server 'kurma-robots-stage-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db]
 
-# for ubuntu to perform resque:pool:hot_swap
-set :pty, true
-
 Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'staging'


### PR DESCRIPTION
## Why was this change made? 🤔

prod switched to ubuntu.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


