### PR TITLE
Set concurrency to 1 to avoid issues with Dir.chdir.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,7 @@
 ---
-:concurrency: 5
+# The concurrency is set to 1 since Dir.chdir is used, which is not thread safe.
+# See https://bugs.ruby-lang.org/issues/15661
+:concurrency: 1
 :queues:
   - gisAssemblyWF_default
   - gisDeliveryWF_default


### PR DESCRIPTION
closes #601

## Why was this change made? 🤔
Allow GIS robots to run without errors.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


