### PR TITLE
Enable new cops and fix linting errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -442,3 +442,20 @@ RSpec/Rails/MinitestAssertions: # new in 2.17
   Enabled: true
 RSpec/Rails/TravelAround: # new in 2.19
   Enabled: true
+
+Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: true
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true
+RSpec/ReceiveMessages: # new in 2.23
+  Enabled: true
+RSpec/Rails/NegationBeValid: # new in 2.23
+  Enabled: true

--- a/lib/gis_robot_suite.rb
+++ b/lib/gis_robot_suite.rb
@@ -54,11 +54,11 @@ module GisRobotSuite
   end
 
   def self.vector?(mimetype)
-    %w[application/x-esri-shapefile].include? mimetype.split(/;/).first.strip
+    %w[application/x-esri-shapefile].include? mimetype.split(';').first.strip
   end
 
   def self.raster?(mimetype)
-    %w[image/tiff application/x-ogc-aig].include? mimetype.split(/;/).first.strip
+    %w[image/tiff application/x-ogc-aig].include? mimetype.split(';').first.strip
   end
 
   def self.locate_druid_path(druid, opts = {})

--- a/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
@@ -98,9 +98,9 @@ module Robots
               # Center      (-122.0970582,  35.7676061) (122d 5'49.41"W, 35d46' 3.38"N)
               case line
               when /^Upper Left\s+\((.*)\)\s+\(/
-                ulx, uly = Regexp.last_match(1).split(/,/)
+                ulx, uly = Regexp.last_match(1).split(',')
               when /^Lower Right\s+\((.*)\)\s+\(/
-                lrx, lry = Regexp.last_match(1).split(/,/)
+                lrx, lry = Regexp.last_match(1).split(',')
               end
             end
             return [ulx, uly, lrx, lry].map { |x| x.to_s.strip.to_f }

--- a/lib/robots/dor_repo/gis_assembly/normalize_data.rb
+++ b/lib/robots/dor_repo/gis_assembly/normalize_data.rb
@@ -41,7 +41,7 @@ module Robots
             projection = GisRobotSuite.determine_projection_from_mods mods_filename
             projection.gsub!('ESRI', 'EPSG')
             logger.debug "Projection = #{projection}"
-            filetype = format.split(/format=/)[1]
+            filetype = format.split('format=')[1]
             raise "normalize-data: #{bare_druid} cannot locate filetype from MODS format: #{format}" if filetype.nil?
 
             case filetype

--- a/spec/robots/dor_repo/gis_assembly/load_geo_metadata_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/load_geo_metadata_spec.rb
@@ -42,10 +42,8 @@ RSpec.describe Robots::DorRepo::GisAssembly::LoadGeoMetadata do
     end
 
     before do
-      allow(File).to receive(:size?).and_return(100)
+      allow(File).to receive_messages(size?: 100, read: xml, mtime: Time.now)
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(File).to receive(:read).and_return(xml)
-      allow(File).to receive(:mtime).and_return(Time.now)
     end
 
     it 'tags the object' do


### PR DESCRIPTION
## Why was this change made? 🤔

Enable new cops, autocorrect errors.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


