### PR TITLE
Unbreak rake etc

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,6 @@ require 'rake'
 # Import external rake tasks
 Dir.glob('lib/tasks/*.rake').each { |r| import r }
 
-desc 'Get application version'
-task :app_version do
-  puts File.read('VERSION')
-end
-
 desc 'Load complete environment into rake process'
 task :environment do
   require_relative 'config/boot'
@@ -36,4 +31,4 @@ rescue LoadError
   end
 end
 
-task default: [:app_version, :spec, :rubocop]
+task default: [:spec, :rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rake'
-require 'resque/pool/tasks'
 
 # Import external rake tasks
 Dir.glob('lib/tasks/*.rake').each { |r| import r }
@@ -15,8 +14,6 @@ desc 'Load complete environment into rake process'
 task :environment do
   require_relative 'config/boot'
 end
-
-task 'resque:setup' => :environment
 
 begin
   require 'rspec/core/rake_task'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,7 +19,8 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 # set :log_level, :debug
 
 # Default value for :pty is false
-# true for ubuntu to perform resque:pool:hot_swap
+# switched to true for ubuntu to perform resque:pool:hot_swap (prevented terminal session from hanging).
+# seems harmless even after switch to sidekiq.
 set :pty, true
 
 # Default value for :linked_files is []

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,2 @@
-redis:
-  url: 'localhost:6379/resque:test'
-
 geohydra:
   workspace: 'spec/fixtures/workspace'


### PR DESCRIPTION
## Why was this change made? 🤔

noticed that default `bundle exec rake` ran into errors around the things cleaned up in this commit (error trying to create Resque related Rake tasks since switch to Sidekiq, error trying to load `VERSION` file that was removed for lack of usefulness)

## How was this change tested? 🤨

`bundle exec rake` on dev laptop, CI

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


