### PR TITLE
restore start_assembly_workflow.rb and start_delivery_workflow.rb

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/start_assembly_workflow.rb
+++ b/lib/robots/dor_repo/gis_assembly/start_assembly_workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module GisAssembly
+      class StartAssemblyWorkflow < Base
+        def initialize
+          super('gisAssemblyWF', 'start-assembly-workflow')
+        end
+
+        def perform_work
+          logger.debug "start-assembly-workflow working on #{bare_druid}"
+          current_version = object_client.version.current
+          workflow_service.create_workflow_by_name(druid, 'assemblyWF', version: current_version)
+        end
+      end
+    end
+  end
+end

--- a/lib/robots/dor_repo/gis_assembly/start_delivery_workflow.rb
+++ b/lib/robots/dor_repo/gis_assembly/start_delivery_workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module GisAssembly
+      class StartDeliveryWorkflow < Base
+        def initialize
+          super('gisAssemblyWF', 'start-delivery-workflow')
+        end
+
+        def perform_work
+          logger.debug "start-delivery-workflow working on #{bare_druid}"
+          current_version = object_client.version.current
+          workflow_service.create_workflow_by_name(druid, 'gisDeliveryWF', version: current_version)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

I'm not sure of the need for this PR;  I have a feeling that there is some confusion as to what some of the workflow steps do.  There are some oddities to how the workflow code actually works in RL, for sure.

The Infrastructure integration test isn't passing because there's no automatic trigger of common-accessioning (which is what `gis_assembly/start_assembly_workflow.rb` step does).

It's possible that gis-delivery-workflow is no longer needed ... but since the code is still in the repo ... maybe it is still desired?

Feel free to close this PR or do whatever is appropriate;  however, please make sure the infrastructure integration test is testing the right thing and will pass as changes move along.

## How was this change tested? 🤨

With things as they stand without this PR, the infrastructure integration test for gis does NOT pass.   Maybe that's okay for now;   as FR, I'm not sure.  So I'm going to proceed to deployment without the gis test passing..



