### PR TITLE
Restore start delivery workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ These robots require several dependencies needed to perform the GIS workflow ste
 * `generate-content-metadata` :: Generate contentMetadata manifest
 * `load-geo-metadata` :: Accession geoMetadata xml into SDR
 * `finish-gis-assembly-workflow` :: Finalize assembly workflow to prepare for assembly/delivery/discovery (validity check)
+* `start-delivery-workflow` :: Kickstart the GIS delivery workflow at gisDeliveryWF
+
 
 `gisDeliveryWF`
 ---------------

--- a/lib/robots/dor_repo/gis_assembly/start_delivery_workflow.rb
+++ b/lib/robots/dor_repo/gis_assembly/start_delivery_workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module GisAssembly
+      class StartDeliveryWorkflow < Base
+        def initialize
+          super('gisAssemblyWF', 'start-delivery-workflow')
+        end
+
+        def perform_work
+          logger.debug "start-delivery-workflow working on #{bare_druid}"
+          current_version = object_client.version.current
+          workflow_service.create_workflow_by_name(druid, 'gisDeliveryWF', version: current_version)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #668 to start gisDeliveryWF at end of gisAssemblyWF.

## How was this change tested? 🤨
Updated the integration test and ran on stage. 

