### PR TITLE
Avoid dupe retrieval when checking rights.

### DIFF
--- a/lib/gis_robot_suite.rb
+++ b/lib/gis_robot_suite.rb
@@ -125,11 +125,9 @@ module GisRobotSuite
     proj.to_s.upcase
   end
 
-  def self.determine_rights(druid)
-    rights = 'Restricted'
-    cocina_model = Dor::Services::Client.object("druid:#{druid}").find
-    rights = 'Public' if cocina_model.access.view == 'world'
+  def self.determine_rights(cocina_model)
+    return 'public' if cocina_model.access.view == 'world'
 
-    rights
+    'restricted'
   end
 end

--- a/lib/robots/dor_repo/gis_delivery/load_geoserver.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_geoserver.rb
@@ -22,7 +22,7 @@ module Robots
           format = GisRobotSuite.determine_file_format_from_mods modsfn
           raise "load-geoserver: #{bare_druid} cannot determine file format from MODS" if format.nil?
 
-          rights = GisRobotSuite.determine_rights(bare_druid).downcase
+          rights = GisRobotSuite.determine_rights(cocina_object)
           # reproject based on file format information
           if GisRobotSuite.vector?(format)
             layertype = 'PostGIS'

--- a/lib/robots/dor_repo/gis_delivery/reset_geowebcache.rb
+++ b/lib/robots/dor_repo/gis_delivery/reset_geowebcache.rb
@@ -11,7 +11,7 @@ module Robots
         def perform_work
           logger.debug "reset-geowebcache working on #{druid}"
 
-          rights = GisRobotSuite.determine_rights(bare_druid).downcase
+          rights = GisRobotSuite.determine_rights(cocina_object)
           ##
           # Truncate the cache for the layer in every place
           Settings.geoserver[rights].map do |_key, setting|

--- a/spec/robots/dor_repo/gis_delivery/load_geoserver_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_geoserver_spec.rb
@@ -5,16 +5,18 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::GisDelivery::LoadGeoserver do
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: instance_double(Cocina::Models::DRO)) }
 
   before do
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     stub_request(:get, 'http://example.com/geoserver/rest/workspaces/druid')
       .to_return(status: 200, body: read_fixture('geoserver_responses/workspaces.json'), headers: {})
   end
 
   describe '#perform' do
     before do
-      allow(GisRobotSuite).to receive(:determine_rights).and_return 'Public'
+      allow(GisRobotSuite).to receive(:determine_rights).and_return 'public'
     end
 
     describe 'loading a vector dataset' do

--- a/spec/robots/dor_repo/gis_delivery/reset_geowebcache_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/reset_geowebcache_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Robots::DorRepo::GisDelivery::ResetGeowebcache do
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
   let(:druid) { 'druid:fx392st8577' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: instance_double(Cocina::Models::DRO)) }
 
   before do
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
-    allow(GisRobotSuite).to receive(:determine_rights).and_return 'Public'
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(GisRobotSuite).to receive(:determine_rights).and_return 'public'
   end
 
   describe '#perform' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require File.expand_path("#{__dir__}/../config/boot")
 
 require 'pry'
 require 'rspec'
+require 'cocina/rspec'
 include LyberCore::Rspec # rubocop:disable Style/MixinUsage
 
 def read_fixture(fname)

--- a/spec/unit/utils_spec.rb
+++ b/spec/unit/utils_spec.rb
@@ -22,48 +22,20 @@ RSpec.describe 'utilities' do
   end
 
   describe '.determine_rights' do
-    subject { GisRobotSuite.determine_rights(druid) }
+    subject { GisRobotSuite.determine_rights(cocina_object) }
 
-    let(:object_client) do
-      instance_double(Dor::Services::Client::Object, find: cocina_model)
-    end
-    let(:druid) { 'fx392st8577' }
-    let(:cocina_model) do
-      Cocina::Models.build({
-                             'externalIdentifier' => 'druid:fx392st8577',
-                             'label' => 'GIS object',
-                             'version' => 1,
-                             'type' => Cocina::Models::ObjectType.object,
-                             'description' => {
-                               'title' => [{ 'value' => 'GIS object' }],
-                               'purl' => 'https://purl.stanford.edu/fx392st8577'
-                             },
-                             'access' => {
-                               'view' => access,
-                               'download' => access
-                             },
-                             'structural' => {},
-                             identification: { sourceId: 'sul:1234' },
-                             'administrative' => {
-                               'hasAdminPolicy' => 'druid:xx999xx9999'
-                             }
-                           })
-    end
-
-    before do
-      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    end
+    let(:cocina_object) { build(:dro).new(access: { view: access, download: access }) }
 
     context 'when public' do
       let(:access) { 'world' }
 
-      it { is_expected.to be 'Public' }
+      it { is_expected.to be 'public' }
     end
 
     context 'when restricted' do
       let(:access) { 'stanford' }
 
-      it { is_expected.to be 'Restricted' }
+      it { is_expected.to be 'restricted' }
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
The robot already retrieves cocina object.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Unit
