### PR TITLE
Add info about XML dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Robot code for accessioning and delivery of GIS resources.
 These robots require several dependencies needed to perform the GIS workflow steps. These are often shelled out to using `system` calls.
 
  - [GDAL](https://gdal.org/) Needed for several geospatial tasks. Also needed on servers are the utils and clients
+ - `xsltproc` and `xmllint` for transforming XML files
  - rsync also used as part of the robot process and is needed
 
 # Documentation


### PR DESCRIPTION
## Why was this change made? 🤔

I discovered that we couldn't test the robots that transform XML in CI without installing these dependencies, so I decided to document them.

## How was this change tested? 🤨

The CI workflow now installs them and runs successfully as of #678 


