### PR TITLE
Refactor extract-iso19139 robot

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/extract_iso19139.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_iso19139.rb
@@ -11,61 +11,96 @@ module Robots
         def perform_work
           logger.debug "extract-iso19139 working on #{bare_druid}"
 
-          rootdir = GisRobotSuite.locate_druid_path(bare_druid, type: :stage)
-
           # See if generation is needed
-          geo_metadata_filename = File.join(rootdir, 'metadata', 'geoMetadata.xml')
+          geo_metadata_filename = File.join(staging_dir, 'metadata', 'geoMetadata.xml')
           if File.size?(geo_metadata_filename)
             logger.info "extract-iso19139: #{bare_druid} found #{geo_metadata_filename}"
             return
           end
 
-          begin
-            esri_filename = GisRobotSuite.locate_esri_metadata("#{rootdir}/temp")
-            if esri_filename =~ /^(.*).(shp|tif).xml$/ || esri_filename =~ %r{^(.*/metadata).xml$}
-              output_file = "#{Regexp.last_match(1)}-iso19139.xml"
-              ofn_fc = "#{Regexp.last_match(1)}-iso19110.xml"
-              ofn_fgdc = "#{Regexp.last_match(1)}-fgdc.xml"
-            end
-            logger.debug "extract-iso19139 working on #{esri_filename}"
-            arcgis_to_iso19139(esri_filename, output_file, ofn_fc, ofn_fgdc)
-          rescue RuntimeError => e
-            logger.error "extract-iso19139: #{bare_druid} is missing ESRI metadata files"
-            raise e
-          end
+          # Generate ISO 19139 and FGDC for all data types
+          generate_iso19139
+          generate_fgdc
+
+          # Only generate ISO 19110 if it's a Shapfile, which has a feature catalog
+          generate_iso19110 if data_type == 'Shapefile'
         end
 
         private
 
-        # XSLT file locations
-        XSLT = {
-          arcgis: 'config/ArcGIS/Transforms/ArcGIS2ISO19139.xsl',
-          arcgis_fc: 'lib/xslt/arcgis_to_iso19110.xsl',
-          arcgis_fgdc: 'config/ArcGIS/Transforms/ArcGIS2FGDC.xsl'
-        }.freeze
+        # Staging directory for this object
+        def staging_dir
+          GisRobotSuite.locate_druid_path(bare_druid, type: :stage)
+        end
 
-        # XSLT processor
-        XSLTPROC = 'xsltproc --novalid --xinclude'
-        # XML cleaner
-        XMLLINT = 'xmllint --format --xinclude --nsclean'
+        # XML metadata file exported from ArcGIS
+        def esri_metadata_file
+          GisRobotSuite.locate_esri_metadata(File.join(staging_dir, 'temp'))
+        rescue RuntimeError => e
+          logger.error "extract-iso19139: #{bare_druid} is missing ESRI metadata file"
+          raise e
+        end
 
-        # Converts an ESRI ArcCatalog metadata.xml into ISO 19139
-        # @param [String] input_file Input file
-        # @param [String] output_file Output file
-        # @param [String] ofn_fc Output file for the Feature Catalog (optional)
-        def arcgis_to_iso19139(input_file, output_file, ofn_fc = nil, ofn_fgdc = nil)
-          logger.info "generating #{output_file}"
-          # Root of the project.  This is needed to find the XSLT files.
-          basepath = File.absolute_path("#{__FILE__}/../../../../..")
-          system("#{XSLTPROC} #{File.join(basepath, XSLT[:arcgis])} '#{input_file}' | #{XMLLINT} -o '#{output_file}' -", exception: true)
-          unless ofn_fc.nil?
-            logger.info "generating #{ofn_fc}"
-            system("#{XSLTPROC} #{File.join(basepath, XSLT[:arcgis_fc])} '#{input_file}' | #{XMLLINT} -o '#{ofn_fc}' -", exception: true)
+        # Type of GIS data for this object
+        def data_type
+          file_name = File.basename(esri_metadata_file)
+          return 'ArcGRID' if file_name == 'metadata.xml'
+          return 'Shapefile' if file_name.end_with?('.shp.xml')
+          return 'GeoTIFF' if file_name.end_with?('.tif.xml')
+
+          raise "extract-iso19139: #{bare_druid} has unknown GIS data type"
+        end
+
+        # Filename of the original GIS metadata without any extensions
+        def layer_name
+          case data_type
+          when 'Shapefile'
+            File.basename(esri_metadata_file, '.shp.xml')
+          when 'GeoTIFF'
+            File.basename(esri_metadata_file, '.tif.xml')
+          when 'ArcGRID'
+            File.basename(File.dirname(esri_metadata_file))
           end
-          return if ofn_fgdc
+        end
 
-          logger.info "generating #{ofn_fgdc}"
-          system("#{XSLTPROC} #{File.join(basepath, XSLT[:arcgis_fgdc])} '#{input_file}' | #{XMLLINT} -o '#{ofn_fgdc}' -", exception: true)
+        # Directory where XSL transforms are located
+        def xslt_path
+          File.join(Dir.pwd, 'config', 'ArcGIS', 'Transforms')
+        end
+
+        # Comand to invoke xsltproc to transform XML
+        def xslt_command
+          'xsltproc --novalid --xinclude'
+        end
+
+        # Command to post-process transformed XML with xmllint
+        def xml_lint_command
+          'xmllint --format --xinclude --nsclean'
+        end
+
+        # Apply an XSL transform to the ESRI metadata file
+        def transform_arcgis_metadata(output_file, xslt_name)
+          logger.info "generating #{output_file}"
+          xslt_file = File.join(xslt_path, xslt_name)
+          system("#{xslt_command} #{xslt_file} '#{esri_metadata_file}' | #{xml_lint_command} -o '#{output_file}' -", exception: true)
+        end
+
+        # Generate ISO 19139 metadata from ESRI metadata
+        def generate_iso19139
+          output_file = File.join(staging_dir, 'temp', "#{layer_name}-iso19139.xml")
+          transform_arcgis_metadata(output_file, 'ArcGIS2ISO19139.xsl')
+        end
+
+        # Generate ISO 19110 metadata from ESRI metadata
+        def generate_iso19110
+          output_file = File.join(staging_dir, 'temp', "#{layer_name}-iso19110.xml")
+          transform_arcgis_metadata(output_file, 'arcgis_to_iso19110.xsl')
+        end
+
+        # Generate FGDC metadata from ESRI metadata
+        def generate_fgdc
+          output_file = File.join(staging_dir, 'temp', "#{layer_name}-fgdc.xml")
+          transform_arcgis_metadata(output_file, 'ArcGIS2FGDC.xsl')
         end
       end
     end

--- a/spec/robots/dor_repo/gis_assembly/extract_iso19139_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_iso19139_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19139 do
     it 'generates an ISO 19139 XML document' do
       expect(File).to exist(File.join(staging_dir, 'WATER_BODY-iso19139.xml'))
     end
+
+    it 'generates an FGDC XML document' do
+      expect(File).to exist(File.join(staging_dir, 'WATER_BODY-fgdc.xml'))
+    end
+
+    it 'generates an ISO 19110 XML document' do
+      expect(File).to exist(File.join(staging_dir, 'WATER_BODY-iso19110.xml'))
+    end
   end
 
   context 'with ESRI metadata for a geoTIFF' do
@@ -38,6 +46,14 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19139 do
 
     it 'generates an ISO 19139 XML document' do
       expect(File).to exist(File.join(staging_dir, '26257_e-iso19139.xml'))
+    end
+
+    it 'generates an FGDC XML document' do
+      expect(File).to exist(File.join(staging_dir, '26257_e-fgdc.xml'))
+    end
+
+    it 'does not generate an ISO 19110 XML document' do
+      expect(File).not_to exist(File.join(staging_dir, '26257_e-iso19110.xml'))
     end
   end
 end


### PR DESCRIPTION
- Only generate iso19110 if we have a shapefile
- Make sure we generate fgdc for all data types
- Cleaner method for getting the project directory
- General code cleanup and documentation

Fixes #104
Fixes #583
