### PR TITLE
Remove geoMetadata check from extract_iso19139

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/extract_iso19139.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_iso19139.rb
@@ -11,13 +11,6 @@ module Robots
         def perform_work
           logger.debug "extract-iso19139 working on #{bare_druid}"
 
-          # See if generation is needed
-          geo_metadata_filename = File.join(staging_dir, 'metadata', 'geoMetadata.xml')
-          if File.size?(geo_metadata_filename)
-            logger.info "extract-iso19139: #{bare_druid} found #{geo_metadata_filename}"
-            return
-          end
-
           # Generate ISO 19139 and FGDC for all data types
           generate_iso19139
           generate_fgdc


### PR DESCRIPTION
## Why was this change made? 🤔
Partially addresses #665 to remove geoMetadata check from workflow steps. We should follow the rest of the existing logic to generate the metadata in this step. 

## How was this change tested? 🤨
Unit.


