### PR TITLE
Remove checks for descMetadata.xml

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/finish_gis_assembly_workflow.rb
+++ b/lib/robots/dor_repo/gis_assembly/finish_gis_assembly_workflow.rb
@@ -20,7 +20,6 @@ module Robots
             content/data_EPSG_4326.zip
             content/preview.jpg
             metadata/contentMetadata.xml
-            metadata/descMetadata.xml
             metadata/geoMetadata.xml
           ].each do |f|
             fn = File.join(rootdir, f)

--- a/lib/robots/dor_repo/gis_assembly/finish_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/finish_metadata.rb
@@ -13,12 +13,10 @@ module Robots
 
           rootdir = GisRobotSuite.locate_druid_path bare_druid, type: :stage
 
-          %w[descMetadata.xml geoMetadata.xml].each do |f|
-            fn = File.join(rootdir, 'metadata', f)
-            raise "finish-metadata: #{bare_druid} is missing metadata: #{fn}" unless File.size?(fn)
+          fn = File.join(rootdir, 'metadata', 'geoMetadata.xml')
+          raise "finish-metadata: #{bare_druid} is missing metadata: #{fn}" unless File.size?(fn)
 
-            logger.info "finish-metadata found #{fn} #{File.size(fn)} bytes"
-          end
+          logger.info "finish-metadata found #{fn} #{File.size(fn)} bytes"
 
           %w[preview.jpg].each do |f|
             fn = File.join(rootdir, 'content', f)


### PR DESCRIPTION
## Why was this change made? 🤔
So that descMetadata.xml can be removed.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


