### PR TITLE
Remove dependence on descMetadata.xml from Generate Content Metadata robot

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/generate_content_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_content_metadata.rb
@@ -30,11 +30,7 @@ module Robots
             end
           end
 
-          # extract the MODS extension cleanly
-          modsfn = "#{rootdir}/metadata/descMetadata.xml"
-          raise "generate-content-metadata: #{bare_druid} is missing MODS metadata" unless File.size?(modsfn)
-
-          doc = Nokogiri::XML(File.read(modsfn))
+          doc = Cocina::Models::Mapping::ToMods::Description.transform(cocina_object.description, druid)
           ns = {
             'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
             'mods' => 'http://www.loc.gov/mods/v3'


### PR DESCRIPTION
## Why was this change made? 🤔
So the descMetadata.xml can be removed.

Note that this PR does the least bit possible, as there is a separate ticket for refactoring this robot more broadly.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

It isn't.