### PR TITLE
Refactor load raster robot to not use descMetadata.xml

### DIFF
--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -14,14 +14,7 @@ module Robots
           rootdir = GisRobotSuite.locate_druid_path bare_druid, type: :workspace
 
           # determine whether we have a Raster to load
-          modsfn = File.join(rootdir, 'metadata', 'descMetadata.xml')
-          raise "load-raster: #{bare_druid} cannot locate MODS: #{modsfn}" unless File.size?(modsfn)
-
-          format = GisRobotSuite.determine_file_format_from_mods modsfn
-          raise "load-raster: #{bare_druid} cannot determine file format from MODS: #{modsfn}" if format.nil?
-
-          # perform based on file format information
-          unless GisRobotSuite.raster?(format)
+          unless GisRobotSuite.raster?(cocina_object)
             logger.info "load-raster: #{bare_druid} is not a raster, skipping"
             return
           end


### PR DESCRIPTION
## Why was this change made? 🤔
So that no longer need descMetadata.xml


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

It isn't.
