### PR TITLE
Change basepath for transforms dir

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/extract_iso19139.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_iso19139.rb
@@ -58,7 +58,9 @@ module Robots
 
         # Directory where XSL transforms are located
         def xslt_path
-          File.join(Dir.pwd, 'config', 'ArcGIS', 'Transforms')
+          # Root of the project.  This is needed to find the XSLT files.
+          basepath = File.absolute_path("#{__FILE__}/../../../../..")
+          File.join(basepath, 'config', 'ArcGIS', 'Transforms')
         end
 
         # Comand to invoke xsltproc to transform XML
@@ -73,8 +75,8 @@ module Robots
 
         # Apply an XSL transform to the ESRI metadata file
         def transform_arcgis_metadata(output_file, xslt_name)
-          logger.info "generating #{output_file}"
           xslt_file = File.join(xslt_path, xslt_name)
+          logger.info("generating #{output_file} using #{xslt_file}")
           system("#{xslt_command} #{xslt_file} '#{esri_metadata_file}' | #{xml_lint_command} -o '#{output_file}' -", exception: true)
         end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes error with `extract_iso19139` step where `xsltproc` was not finding the .xsl file. Restored the previous absolute path for the transforms files. 

## How was this change tested? 🤨
Integration test and added logging. 

BEFORE: was looking for `.xsl` in:
`/gis_workflow_data/stage/sr240kw9105/temp/config/ArcGIS/Transforms/ArcGIS2ISO19139.xsl`

AFTER:
`generating /gis_workflow_data/stage/wg313th2970/temp/AirMonitoringStations-iso19139.xml using /opt/app/lyberadmin/gis-robot-suite/releases/20240122155528/config/ArcGIS/Transforms/ArcGIS2ISO19139.xsl`
