### PR TITLE
Remove use of Dir.chdir in Extract Boundingbox robot.

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
@@ -218,17 +218,15 @@ module Robots
         #
         # @return [Array] ulx uly lrx lry for the bounding box
         def determine_extent
-          Dir.chdir(tmpdir) do
-            shape_filename = Dir.glob('*.shp').first
-            if shape_filename.nil?
-              tiff_filename = Dir.glob('*.tif').first
-              ulx, uly, lrx, lry = extent_geotiff tiff_filename # normalized version only
-            else
-              ulx, uly, lrx, lry = extent_shapefile shape_filename
-            end
-            logger.debug [ulx, uly, lrx, lry].join(' -- ')
-            return [ulx, uly, lrx, lry]
+          shape_filename = Dir.glob("#{tmpdir}/*.shp").first
+          if shape_filename.nil?
+            tiff_filename = Dir.glob("#{tmpdir}/*.tif").first
+            ulx, uly, lrx, lry = extent_geotiff tiff_filename # normalized version only
+          else
+            ulx, uly, lrx, lry = extent_shapefile shape_filename
           end
+          logger.debug [ulx, uly, lrx, lry].join(' -- ')
+          [ulx, uly, lrx, lry]
         end
 
         def check_extent(ulx, uly, lrx, lry)

--- a/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
@@ -378,5 +378,6 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
   it 'updates the cocina with the bounding box' do
     test_perform(robot, druid)
     expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
+    expect(IO).to have_received(:popen).with("gdalinfo '/tmp/extractboundingbox_nj441df9572/MCE_AF2G_2010.tif'")
   end
 end


### PR DESCRIPTION
closes #601

## Why was this change made? 🤔
Dir.chdir was causing intermittent `Errno::ENOENT: No such file or directory - getcwd` errors.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Unit
