### PR TITLE
Add step to kick off accessionWF

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Kim Durante &amp; Darren Hardy (2015) Discovery, Management, and Preservation of
 * `load-raster` :: Load raster into GeoTIFF data store
 * `load-geoserver` :: Load layers into GeoServer
 * `reset-geowebcache` :: Reset GeoWebCache for the layer
+* `finish-gis-delivery-workflow` :: Connect to public and restricted GeoServers to verify layer
+* `start-accession-workflow` :: Start accessionWF
 
 Data Wrangling
 ==============

--- a/bin/run_delivery
+++ b/bin/run_delivery
@@ -11,6 +11,7 @@ for s in \
   load-geoserver \
   reset-geowebcache \
   finish-gis-delivery-workflow \
+  start-accession-workflow \
   ; do
   bundle exec run_robot dor:gisDeliveryWF:$s -d $druid
 done

--- a/lib/robots/dor_repo/gis_delivery/start_accession_workflow.rb
+++ b/lib/robots/dor_repo/gis_delivery/start_accession_workflow.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module GisDelivery
+      class StartAccessionWorkflow < Base
+        def initialize
+          super('gisDeliveryWF', 'start-accession-workflow')
+        end
+
+        def perform_work
+          logger.debug "start-accession-workflow working on #{bare_druid}"
+          current_version = object_client.version.current
+          workflow_service.create_workflow_by_name(druid, 'accessionWF', version: current_version)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #715 to kick off accessionWF after gisDeliveryWF. Goes with workflow-server PR: https://github.com/sul-dlss/workflow-server-rails/pull/711

## How was this change tested? 🤨
Tested with integration test on a branch. (See PR )

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


