### PR TITLE
Add an alpha layer to GeoTIFF raster data

### DIFF
--- a/spec/robots/dor_repo/gis_assembly/normalize_data_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/normalize_data_spec.rb
@@ -177,6 +177,10 @@ RSpec.describe Robots::DorRepo::GisAssembly::NormalizeData do
         expect(Kernel).to have_received(:system).with(
           "gdal_translate -expand rgb /tmp/normalize_bb021mm7809/raw8bit.tif /tmp/normalize_bb021mm7809/EPSG_4326/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'"
         )
+        # Adds an alpha channel
+        expect(Kernel).to have_received(:system).with(
+          'gdalwarp -dstalpha /tmp/normalize_bb021mm7809/EPSG_4326/MCE_FI2G_2014.tif /tmp/normalize_bb021mm7809/EPSG_4326/MCE_FI2G_2014_alpha.tif'
+        )
         # Stats
         expect(Kernel).to have_received(:system).with(
           'gdalinfo -mm -stats -norat -noct /tmp/normalize_bb021mm7809/EPSG_4326/MCE_FI2G_2014.tif'


### PR DESCRIPTION
## Why was this change made? 🤔

We want to add an alpha channel to GeoTIFF files so they display well in GeoServer. Note, an alpha layer is always added (to single and 3 band GeoTIFF files) since gdalwarp doesn't add a new alpha band if one is already present.

Fixes #570

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


