### PR TITLE
Fix run_robot script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'config', '~> 3.1'
 gem 'fastimage', '~> 2.2' # to get mimetype in GenerateContentMetadata
 gem 'pry', '~> 0.10' # for console
 gem 'rake', '~> 13.0'
-gem 'slop', '~> 3.6' # for bin/run_robot
+gem 'slop' # for bin/run_robot
 gem 'honeybadger'
 gem 'scanf'
 gem 'sidekiq', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     jsonpath (1.1.5)
       multi_json
     language_server-protocol (3.17.0.3)
-    lyber-core (7.4.1)
+    lyber-core (7.4.2)
       activesupport
       config
       dor-services-client (~> 14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    slop (3.6.0)
+    slop (4.10.1)
     sshkit (1.22.0)
       mutex_m
       net-scp (>= 1.1.2)
@@ -342,7 +342,7 @@ DEPENDENCIES
   sidekiq (~> 7.0)
   sidekiq-pro!
   simplecov
-  slop (~> 3.6)
+  slop
   stanford-mods
   webmock
   zeitwerk (~> 2.1)

--- a/bin/run_robot
+++ b/bin/run_robot
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
@@ -27,7 +26,7 @@ robot = ARGV.shift
 opts = slop.to_h
 
 ENV['ROBOT_ENVIRONMENT'] = opts[:environment] unless opts[:environment].nil?
-require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
+require File.expand_path("#{File.dirname(__FILE__)}/../config/boot")
 
 # instantiate a Robot object using the name
 klazz = robot.split('::').inject(Robots::DorRepo) { |o, c| o.const_get c }
@@ -35,11 +34,11 @@ bot = klazz.new
 bot.check_queued_status = false # skipping the queued workflow status check
 
 druids = if opts[:file]
-           IO.readlines(opts[:file]).map(&:strip)
+           File.readlines(opts[:file]).map(&:strip)
          else
            [opts[:druid]]
          end
 
 druids.each do |druid|
-  bot.work druid
+  bot.perform druid
 end


### PR DESCRIPTION
## Why was this change made? 🤔

The run_robot script is currently broken and needs to be updated.  This has it match what is in common_accessioning.

BUT: the run_robot will not actually run a step, unless it is in the `queued` state (this is true of common_accessioning too) because of a change that happened in `lyber-core` about 1 year ago here: https://github.com/sul-dlss/lyber-core/commit/628a2c37e2c2178423e082dbe60a5453eb959b9d  where we removed the ability to skip the `queued` state check.

~~This PR would add the ability back into `lyber-core`: https://github.com/sul-dlss/lyber-core/pull/152~~

~~If accepted, we would need to cut a new release and then use it here.~~ DONE

## How was this change tested? 🤨

On stage


