### PR TITLE
config gem unpinned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'geoserver-publish', '>= 0.5.0' # samvera labs
 gem 'lyber-core', '~> 7.1'
 gem 'stanford-mods' # for GisDelivery::LoadGeoserver
 
-gem 'config', '~> 3.1' # Naomi thinks the version restriction can be removed
+gem 'config'
 gem 'fastimage', '~> 2.2' # to get mimetype in GenerateContentMetadata
 gem 'honeybadger'
 gem 'pry' # for console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     coderay (1.1.3)
     commonmarker (0.23.10)
     concurrent-ruby (1.2.3)
-    config (3.1.1)
+    config (5.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     connection_pool (2.4.1)
@@ -322,7 +322,7 @@ DEPENDENCIES
   capistrano
   capistrano-bundler
   capistrano-shared_configs
-  config (~> 3.1)
+  config
   debug
   dlss-capistrano
   dor-services-client (~> 14.0)


### PR DESCRIPTION
## Why was this change made? 🤔

There was/is no need to pin the config gem

## How was this change tested? 🤨

integration test for gis robots
