### PR TITLE
raise error if geoserver call fails

### DIFF
--- a/lib/robots/dor_repo/gis_delivery/reload_geoserver.rb
+++ b/lib/robots/dor_repo/gis_delivery/reload_geoserver.rb
@@ -29,6 +29,7 @@ module Robots
               connection.post(path: '/reload', payload: nil)
             rescue Geoserver::Publish::Error => e
               logger.warn(e.message)
+              raise "reload-geoserver: GeoServer API call failed with #{e.message}"
             end
           end
         end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #774 - raise error on failed API call (should put step in error state)

## How was this change tested? 🤨

