### PR TITLE
Rename generate-content-metadata robot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'lyber-core', '~> 7.1'
 gem 'stanford-mods' # for GisDelivery::LoadGeoserver
 
 gem 'config'
-gem 'fastimage', '~> 2.2' # to get mimetype in GenerateContentMetadata
+gem 'fastimage', '~> 2.2' # to get mimetype in GenerateStructural
 gem 'honeybadger'
 gem 'pry' # for console
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Kim Durante &amp; Darren Hardy (2015) Discovery, Management, and Preservation of
 * `package-data` :: Package the digital work
 * `normalize-data` :: Reproject the data into common SRS projection and/or file format
 * `extract-boundingbox` :: Extract bounding box from data for MODS record
-* `generate-content-metadata` :: Generate structural metadata and update the Cocina data store accordingly
+* `generate-structural` :: Generate structural metadata and update the Cocina data store accordingly
 * `finish-gis-assembly-workflow` :: Finalize assembly workflow to prepare for assembly/delivery/discovery (validity check)
 * `start-delivery-workflow` :: Kickstart the GIS delivery workflow at gisDeliveryWF
 
@@ -48,7 +48,7 @@ Kim Durante &amp; Darren Hardy (2015) Discovery, Management, and Preservation of
 * `load-geoserver` :: Load layers into GeoServer
 * `reset-geowebcache` :: Reset GeoWebCache for the layer
 * `finish-gis-delivery-workflow` :: Connect to public and restricted GeoServers to verify layer
-* `reload-geoserver` :: Automatically reload the GeoServer 
+* `reload-geoserver` :: Automatically reload the GeoServer
 * `start-accession-workflow` :: Start accessionWF
 
 Data Wrangling

--- a/bin/run_assembly
+++ b/bin/run_assembly
@@ -15,7 +15,7 @@ for s in \
   package-data \
   normalize-data \
   extract-boundingbox \
-  generate-content-metadata \
+  generate-structural \
   finish-gis-assembly-workflow \
   ; do
   bundle exec run_robot dor:gisAssemblyWF:$s -d $druid

--- a/lib/robots/dor_repo/gis_assembly/generate_structural.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_structural.rb
@@ -6,13 +6,13 @@ require 'assembly-objectfile'
 module Robots
   module DorRepo
     module GisAssembly
-      class GenerateContentMetadata < Base # rubocop:disable Metrics/ClassLength
+      class GenerateStructural < Base # rubocop:disable Metrics/ClassLength
         def initialize
-          super('gisAssemblyWF', 'generate-content-metadata')
+          super('gisAssemblyWF', 'generate-structural')
         end
 
         def perform_work
-          logger.debug "generate-content-metadata working on #{bare_druid}"
+          logger.debug "generate-structural working on #{bare_druid}"
 
           updated = cocina_object.new(structural: cocina_object.structural.new(contains: contains_params))
           object_client.update(params: updated)

--- a/spec/robots/dor_repo/gis_assembly/generate_structural_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/generate_structural_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Robots::DorRepo::GisAssembly::GenerateContentMetadata do
+RSpec.describe Robots::DorRepo::GisAssembly::GenerateStructural do
   describe '#perform_work' do
     let(:robot) { described_class.new }
     let(:cocina_model) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #784 - rename `generate-content-metadata` to `generate-structural`

Must go with https://github.com/sul-dlss/workflow-server-rails/pull/720

HOLD for coordination with workflow-server-rails deploy

## How was this change tested? 🤨

CI

