### PR TITLE
ReloadGeoserver: add specs, retry connection failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'fastimage', '~> 2.2' # to get mimetype in GenerateStructural
 gem 'honeybadger'
 gem 'pry' # for console
 gem 'rake'
+gem 'retries'
 gem 'scanf'
 gem 'sidekiq', '~> 7.0'
 gem 'slop' # for bin/run_robot

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ GEM
     regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
+    retries (0.0.5)
     rexml (3.2.6)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -334,6 +335,7 @@ DEPENDENCIES
   lyber-core (~> 7.1)
   pry
   rake
+  retries
   rspec
   rspec_junit_formatter
   rubocop

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
+connection_error_max_retries: 3
+
 dor_services:
   url:  'https://dor-services-test.stanford.test'
   token: secret-token

--- a/lib/robots/dor_repo/base.rb
+++ b/lib/robots/dor_repo/base.rb
@@ -3,6 +3,11 @@
 module Robots
   module DorRepo
     class Base < LyberCore::Robot
+      def retries_handler(msg)
+        proc do |exception, attempt_number, _total_delay|
+          logger.warn("#{msg}: try #{attempt_number} failed: #{exception.message}")
+        end
+      end
     end
   end
 end

--- a/lib/robots/dor_repo/gis_delivery/reload_geoserver.rb
+++ b/lib/robots/dor_repo/gis_delivery/reload_geoserver.rb
@@ -26,7 +26,11 @@ module Robots
               }
             )
             begin
-              connection.post(path: 'reload', payload: nil)
+              with_retries(max_tries: Settings.connection_error_max_retries,
+                           handler: retries_handler("Reloading #{setting} Geoserver for #{druid} (#{setting[:url]})"),
+                           rescue: Faraday::TimeoutError) do
+                connection.post(path: 'reload', payload: nil)
+              end
             rescue Geoserver::Publish::Error => e
               logger.warn(e.message)
               raise "reload-geoserver: GeoServer API call failed with #{e.message}"

--- a/spec/robots/dor_repo/gis_delivery/reload_geoserver_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/reload_geoserver_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Robots::DorRepo::GisDelivery::ReloadGeoserver do
+  subject(:reload_geoserver) { test_perform(robot, druid) }
+
+  let(:robot) { described_class.new }
+
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
+  let(:druid) { 'bb338jh0716' }
+  let(:cocina_object_access) { 'world' }
+  let(:cocina_object) do
+    dro = build(:dro, id: "druid:#{druid}")
+    dro.new(
+      access: { view: cocina_object_access, download: cocina_object_access }
+    )
+  end
+
+  let(:conn_public_primary_params) do
+    {
+      'url' => Settings.geoserver.public.primary.url,
+      'user' => Settings.geoserver.public.primary.user,
+      'password' => Settings.geoserver.public.primary.password
+    }
+  end
+  let(:conn_public_replica_params) do
+    {
+      'url' => Settings.geoserver.public.replica.url,
+      'user' => Settings.geoserver.public.replica.user,
+      'password' => Settings.geoserver.public.replica.password
+    }
+  end
+  let(:conn_restricted_primary_params) do
+    {
+      'url' => Settings.geoserver.restricted.primary.url,
+      'user' => Settings.geoserver.restricted.primary.user,
+      'password' => Settings.geoserver.restricted.primary.password
+    }
+  end
+  let(:conn_restricted_replica_params) do
+    {
+      'url' => Settings.geoserver.restricted.replica.url,
+      'user' => Settings.geoserver.restricted.replica.user,
+      'password' => Settings.geoserver.restricted.replica.password
+    }
+  end
+
+  let(:geoserver_conn_public_primary) { instance_double(Geoserver::Publish::Connection) }
+  let(:geoserver_conn_public_replica) { instance_double(Geoserver::Publish::Connection) }
+  let(:geoserver_conn_restricted_primary) { instance_double(Geoserver::Publish::Connection) }
+  let(:geoserver_conn_restricted_replica) { instance_double(Geoserver::Publish::Connection) }
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+  end
+
+  describe '#perform_work' do
+    context 'with an object that is considered public' do
+      before do
+        allow(Geoserver::Publish::Connection).to receive(:new).with(conn_public_primary_params).and_return(geoserver_conn_public_primary)
+        allow(Geoserver::Publish::Connection).to receive(:new).with(conn_public_replica_params).and_return(geoserver_conn_public_replica)
+        allow(geoserver_conn_public_primary).to receive(:post)
+        allow(geoserver_conn_public_replica).to receive(:post)
+        allow(geoserver_conn_restricted_primary).to receive(:post)
+        allow(geoserver_conn_restricted_replica).to receive(:post)
+      end
+
+      it 'posts to the public geoserver instances' do
+        reload_geoserver
+        expect(Geoserver::Publish::Connection).to have_received(:new).with(conn_public_primary_params)
+        expect(geoserver_conn_public_primary).to have_received(:post).with(path: 'reload', payload: nil)
+        expect(Geoserver::Publish::Connection).to have_received(:new).with(conn_public_replica_params)
+        expect(geoserver_conn_public_replica).to have_received(:post).with(path: 'reload', payload: nil)
+      end
+
+      it 'does not post to the restricted geoserver instances' do
+        reload_geoserver
+        expect(Geoserver::Publish::Connection).not_to have_received(:new).with(conn_restricted_primary_params)
+        expect(geoserver_conn_restricted_primary).not_to have_received(:post)
+        expect(Geoserver::Publish::Connection).not_to have_received(:new).with(conn_restricted_replica_params)
+        expect(geoserver_conn_restricted_replica).not_to have_received(:post)
+      end
+    end
+
+    context 'with an object that is considered restricted' do
+      let(:cocina_object_access) { 'stanford' }
+
+      before do
+        allow(Geoserver::Publish::Connection).to receive(:new).with(conn_restricted_primary_params).and_return(geoserver_conn_restricted_primary)
+        allow(Geoserver::Publish::Connection).to receive(:new).with(conn_restricted_replica_params).and_return(geoserver_conn_restricted_replica)
+        allow(geoserver_conn_public_primary).to receive(:post)
+        allow(geoserver_conn_public_replica).to receive(:post)
+        allow(geoserver_conn_restricted_primary).to receive(:post)
+        allow(geoserver_conn_restricted_replica).to receive(:post)
+      end
+
+      it 'does not post to the public geoserver instances' do
+        reload_geoserver
+        expect(Geoserver::Publish::Connection).not_to have_received(:new).with(conn_public_primary_params)
+        expect(geoserver_conn_public_primary).not_to have_received(:post)
+        expect(Geoserver::Publish::Connection).not_to have_received(:new).with(conn_public_replica_params)
+        expect(geoserver_conn_public_replica).not_to have_received(:post)
+      end
+
+      it 'posts to the restricted geoserver instances' do
+        reload_geoserver
+        expect(Geoserver::Publish::Connection).to have_received(:new).with(conn_restricted_primary_params)
+        expect(geoserver_conn_restricted_primary).to have_received(:post).with(path: 'reload', payload: nil)
+        expect(Geoserver::Publish::Connection).to have_received(:new).with(conn_restricted_replica_params)
+        expect(geoserver_conn_restricted_replica).to have_received(:post).with(path: 'reload', payload: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #786

## How was this change tested? 🤨

- [x] CI
  - you can see the new test case for the desired retry behavior [failing in CI for the 2nd commit](https://app.circleci.com/pipelines/github/sul-dlss/gis-robot-suite/1506/workflows/88eeda4f-6421-411a-9773-efb2ee05123c/jobs/2404?invite=true#step-108-36792_134), but [passing in CI when the retry behavior is added in the 3rd commit](https://app.circleci.com/pipelines/github/sul-dlss/gis-robot-suite/1507/workflows/9c2a4669-5e19-47bf-85ab-4e1e1f61fc97/jobs/2406?invite=true#step-108-41175_23).
  - commit 1 just adds tests for the `ReloadGeoserver` happy path, since that class seemed uncovered.
- [x] infra integration tests (`gis_accessioning_spec.rb` and `preassembly_gis_accessioning_spec.rb`

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


