### PR TITLE
extract_bounding_box: projection not project in method name

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
@@ -24,7 +24,7 @@ module Robots
             check_extent
 
             add_extent_to_geographic_subject
-            add_extent_to_project_form
+            add_extent_to_projection_form
 
             object_client.update(params: cocina_object.new(description: description_props))
           ensure
@@ -150,7 +150,7 @@ module Robots
           end
         end
 
-        def add_extent_to_project_form
+        def add_extent_to_projection_form
           # Check to see whether the current native projection is WGS84
           raise "extract-boundingbox: #{bare_druid} is missing map projection!" if projection_forms.empty?
           raise "extract-boundingbox: #{bare_druid} has too many map projections: #{projection_forms.size}" unless projection_forms.size == 1


### PR DESCRIPTION
## Why was this change made? 🤔

Believe it or not, when I was skimming code for making diagrams, I didn't get what a "project form" was and remained confused until I realized it was short for "projection" and did not mean the noun project.

If I've misunderstood, obviously close this PR and delete the branch ... but this is one for the drunken coder test.

## How was this change tested? 🤨

specs - private method.


