### PR TITLE
RasterNormalizer#add_alpha_channel: tweak gdalwarp command so it adds the alpha channel correctly and uses compression when creating the output file

### DIFF
--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -83,19 +83,10 @@ module GisRobotSuite
       # have alpha channels, then we could introspect on the GeoTIFF file with gdalinfo and skip
       # this call to gdalwarp if one is already present.
 
-      # NOTE: the roundabout approach of outputting the alpha channel add to a vrt, and piping that
-      # gdalwarp result to gdal_translate to create an actual compressed tif is an attempt to workaround
-      # a known issue with the compression option being provided directly to gdalwarp.  See:
-      #   https://trac.osgeo.org/gdal/wiki/UserDocs/GdalWarp#GeoTIFFoutput-coCOMPRESSisbroken
-      #   https://gdal.org/programs/gdalwarp.html#compressed-output
-      #   https://gdal.org/user/virtual_file_systems.html#vsistdout-standard-output-streaming
-      #   https://gis.stackexchange.com/questions/89444/file-size-inflation-normal-with-gdalwarp
-
       logger.info "load-raster: adding alpha channel for #{output_filepath}"
       temp_filepath = "#{tmpdir}/#{geo_object_name}_alpha.tif"
-      gdalwarp_cmd = "#{Settings.gdal_path}gdalwarp -dstalpha -of vrt #{output_filepath} /vsistdout/"
-      gdal_translate_cmd = "#{Settings.gdal_path}gdal_translate -co 'compress=LZW' /vsistdin/ #{temp_filepath}"
-      GisRobotSuite.run_system_command("#{gdalwarp_cmd} | #{gdal_translate_cmd}", logger:)
+      gdalwarp_cmd = "#{Settings.gdal_path}gdalwarp -dstalpha -co 'COMPRESS=LZW' -dstnodata 0"
+      GisRobotSuite.run_system_command("#{gdalwarp_cmd} #{output_filepath} #{temp_filepath}", logger:)
       FileUtils.mv(temp_filepath, output_filepath)
     end
 

--- a/spec/gis_robot_suite/raster_normalizer_spec.rb
+++ b/spec/gis_robot_suite/raster_normalizer_spec.rb
@@ -115,6 +115,11 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
           "gdal_translate -expand rgb /tmp/normalizeraster_bb021mm7809/raw8bit.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'",
           logger:
         )
+        # Adds an alpha channel
+        expect(GisRobotSuite).to have_received(:run_system_command).with(
+          "gdalwarp -dstalpha -of vrt /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif /vsistdout/ | gdal_translate -co 'compress=LZW' /vsistdin/ /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014_alpha.tif", # rubocop:disable Layout/LineLength
+          logger:
+        )
       end
     end
 

--- a/spec/gis_robot_suite/raster_normalizer_spec.rb
+++ b/spec/gis_robot_suite/raster_normalizer_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
         )
         # Adds an alpha channel
         expect(GisRobotSuite).to have_received(:run_system_command).with(
-          "gdalwarp -dstalpha -of vrt /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif /vsistdout/ | gdal_translate -co 'compress=LZW' /vsistdin/ /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014_alpha.tif", # rubocop:disable Layout/LineLength
+          "gdalwarp -dstalpha -co 'COMPRESS=LZW' -dstnodata 0 /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014_alpha.tif",
           logger:
         )
       end


### PR DESCRIPTION
## Why was this change made? 🤔

fixes https://github.com/sul-dlss/gis-robot-suite/issues/789
fixes https://github.com/sul-dlss/gis-robot-suite/issues/802
fixes https://github.com/sul-dlss/gis-robot-suite/issues/570 (hopefully!)

## How was this change tested? 🤨

- [x] CI
- [ ] integration tests
  - objects from integration test run with the approach discussed on 2024-02-21: https://argo-stage.stanford.edu/view/dc240ht1711 and https://argo-stage.stanford.edu/view/ty569st1543
- [ ] manual testing of this branch by @kimdurante 

_NOTE:_ as @edsu discovered (noted in [the "Difficult Data" folder](https://drive.google.com/drive/u/0/folders/1gY6_SgLWwJhtJrYsiAG5X5kgda741Lyo)), enabling this compression can sometimes (one case we know of) lead to the alpha channel addition taking many hours.  I realized after putting this PR up that this might occasionally lead to some very long running `normalize-data` jobs.  Happily, the Sidekiq hotswap timeout for the GIS robots is already set to 4 days, which should be sufficient, as far as we've seen.  And that timeout isn't even a hard limit on all gis-robot-suite jobs, just a cap on how long the job can run after a Sidekiq restart (typically triggered when updated code is deployed).  See [here](https://github.com/sul-dlss/puppet/blob/bb3201ff875ce415b3dd0e1a430f7169725f0e0d/hieradata/node/kurma-robots-qa-01.stanford.edu.eyaml#L42), [here](https://github.com/sul-dlss/puppet/blob/bb3201ff875ce415b3dd0e1a430f7169725f0e0d/hieradata/node/kurma-robots-prod-01.stanford.edu.eyaml#L44), and [here](https://github.com/sul-dlss/puppet/blob/bb3201ff875ce415b3dd0e1a430f7169725f0e0d/hieradata/node/kurma-robots-stage-01.stanford.edu.eyaml#L42).


⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


