### PR TITLE
[HOLD] split out tagging to a new workflow step

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Kim Durante &amp; Darren Hardy (2015) Discovery, Management, and Preservation of
 * `extract-iso19110-metadata` :: Transform ISO 19110metadata from ArcCatalog metadata
 * `extract-fgdc-metadata` :: Transform FGDC metadata from ArcCatalog metadata
 * `generate-geo-metadata` :: Convert ISO 19139 metadata into geoMetadata RDF XML file
+* `generate-tag` :: Apply Geo tag to object
 * `generate-mods` :: Convert geoMetadata into MODS
 * `assign-placenames` :: Insert linked data into MODS record from gazetteer
 * `package-data` :: Package the digital work

--- a/bin/run_assembly
+++ b/bin/run_assembly
@@ -10,6 +10,7 @@ for s in \
   extract-iso19110-metadata \
   extract-fgdc-metadata \
   generate-geo-metadata \
+  generate-tag \
   generate-mods \
   assign-placenames \
   package-data \

--- a/lib/robots/dor_repo/gis_assembly/generate_geo_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_geo_metadata.rb
@@ -35,8 +35,6 @@ module Robots
           )
           # Load geo metadata into DOR
           object_client.update(params: updated)
-
-          tag
         end
 
         # Converts a ISO 19139 into RDF-bundled document XML
@@ -58,18 +56,6 @@ module Robots
               </rdf:Description>
             </rdf:RDF>")
           geo_metadata.to_xml(indent: 2, encoding: 'UTF-8')
-        end
-
-        TAG_GIS = 'Dataset : GIS'
-        def tag
-          current_tags = tags_client.list
-          return if current_tags.include?(TAG_GIS)
-
-          tags_client.create(tags: [TAG_GIS])
-        end
-
-        def tags_client
-          object_client.administrative_tags
         end
       end
     end

--- a/lib/robots/dor_repo/gis_assembly/generate_tag.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_tag.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module GisAssembly
+      class GenerateTag < Base
+        def initialize
+          super('gisAssemblyWF', 'generate-tag')
+        end
+
+        TAG_GIS = 'Dataset : GIS'
+
+        def perform_work
+          logger.debug "generate-tag working on #{bare_druid}"
+
+          current_tags = tags_client.list
+          return if current_tags.include?(TAG_GIS)
+
+          tags_client.create(tags: [TAG_GIS])
+        end
+
+        def tags_client
+          object_client.administrative_tags
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #792 - extract object tagging into it's own step.

HOLD since requires coordination with 

## How was this change tested? 🤨

CI and will test on stage


