### PR TITLE
fix exception not raised correctly

### DIFF
--- a/lib/gis_robot_suite/arcgis_metadata_transformer.rb
+++ b/lib/gis_robot_suite/arcgis_metadata_transformer.rb
@@ -50,7 +50,7 @@ module GisRobotSuite
     def esri_metadata_file
       GisRobotSuite.locate_esri_metadata(File.join(staging_dir, 'temp'))
     rescue RuntimeError => e
-      logger&.error "extract-#{format}-metadata: #{bare_druid} is missing ESRI metadata file"
+      logger&.error "extract-#{output}-metadata: #{bare_druid} is missing ESRI metadata file"
       raise e
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

See https://app.honeybadger.io/projects/52899/faults/104878369 triggered by reseting https://argo-stage.stanford.edu/view/druid:bd882yq4680 ... when we hit a problem transforming metadata, we get the wrong exception.  This fixes the raise so it won't break (`format` is undefined and it gets confused with the ruby `format`, `output` is a string for the file we are trying to transform to)

