### PR TITLE
Changes ogrinfo to use json output.

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
@@ -6,6 +6,7 @@ require 'scanf'
 module Robots
   module DorRepo
     module GisAssembly
+      # Updates cocina description with bounding box information extracted from the data files.
       class ExtractBoundingbox < Base
         def initialize
           super('gisAssemblyWF', 'extract-boundingbox')
@@ -20,8 +21,8 @@ module Robots
           raise "extract-boundingbox: #{bare_druid} cannot locate #{tmpdir}" unless File.directory?(tmpdir)
 
           begin
-            @ulx, @uly, @lrx, @lry = determine_extent
-            check_extent
+            @ulx, @uly, @lrx, @lry = determine_extent # from data files
+            check_extent # extent is valid
 
             add_extent_to_geographic_subject
             add_extent_to_projection_form
@@ -69,6 +70,11 @@ module Robots
         def extent_shapefile(shape_filename)
           logger.debug "extract-boundingbox: working on Shapefile: #{shape_filename}"
           IO.popen("#{Settings.gdal_path}ogrinfo -ro -so -al '#{shape_filename}'") do |ogrinfo_io|
+            # When GDAL is upgraded to >= 3.7.0, the -json flag can be added to use JSON output instead of parsing text.
+            # json = JSON.parse(ogrinfo_io.read)
+            # extent = json.dig('layers', 0, 'geometryFields', 0, 'extent')
+            # return [extent[0].to_f, extent[3].to_f, extent[2].to_f, extent[1].to_f]
+
             ogrinfo_io.readlines.each do |line|
               # Extent: (-151.479444, 26.071745) - (-78.085007, 69.432500) --> (W, S) - (E, N)
               next unless line =~ /^Extent:\s+\((.*),\s*(.*)\)\s+-\s+\((.*),\s*(.*)\)/

--- a/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_boundingbox.rb
@@ -21,11 +21,11 @@ module Robots
           raise "extract-boundingbox: #{bare_druid} cannot locate #{tmpdir}" unless File.directory?(tmpdir)
 
           begin
-            @ulx, @uly, @lrx, @lry = determine_extent # from data files
-            check_extent # extent is valid
+            @ulx, @uly, @lrx, @lry = determine_bounding_box # from data files
+            check_bounding_box # bounding box is valid
 
-            add_extent_to_geographic_subject
-            add_extent_to_projection_form
+            add_bounding_box_to_geographic_subject
+            adding_bounding_box_to_projection_form
 
             object_client.update(params: cocina_object.new(description: description_props))
           ensure
@@ -64,10 +64,10 @@ module Robots
           system("unzip -o '#{zip_filename}' -d '#{tmpdir}'", exception: true)
         end
 
-        # Reads the shapefile to determine extent
+        # Reads the shapefile to determine bounding box
         #
         # @return [Array#Float] ulx uly lrx lry
-        def extent_shapefile(shape_filename)
+        def bounding_box_from_shapefile(shape_filename)
           logger.debug "extract-boundingbox: working on Shapefile: #{shape_filename}"
           IO.popen("#{Settings.gdal_path}ogrinfo -ro -so -al '#{shape_filename}'") do |ogrinfo_io|
             # When GDAL is upgraded to >= 3.7.0, the -json flag can be added to use JSON output instead of parsing text.
@@ -89,10 +89,10 @@ module Robots
           end
         end
 
-        # Reads the GeoTIFF to determine extent
+        # Reads the GeoTIFF to determine box
         #
         # @return [Array#Float] ulx uly lrx lry
-        def extent_geotiff(tiff_filename)
+        def bounding_box_from_geotiff(tiff_filename)
           logger.debug "extract-boundingbox: working on GeoTIFF: #{tiff_filename}"
           IO.popen("#{Settings.gdal_path}gdalinfo -json '#{tiff_filename}'") do |gdalinfo_io|
             ulx = 0
@@ -118,7 +118,7 @@ module Robots
           end
         end
 
-        def add_extent_to_geographic_subject
+        def add_bounding_box_to_geographic_subject
           bounding_box_geographic_subjects.each do |subject|
             subject.clear
             subject[:structuredValue] =
@@ -156,7 +156,7 @@ module Robots
           end
         end
 
-        def add_extent_to_projection_form
+        def adding_bounding_box_to_projection_form
           # Check to see whether the current native projection is WGS84
           raise "extract-boundingbox: #{bare_druid} is missing map projection!" if projection_forms.empty?
           raise "extract-boundingbox: #{bare_druid} has too many map projections: #{projection_forms.size}" unless projection_forms.size == 1
@@ -222,19 +222,19 @@ module Robots
         # gets the bounding box for the normalize data in tmpdir
         #
         # @return [Array] ulx uly lrx lry for the bounding box
-        def determine_extent
+        def determine_bounding_box
           shape_filename = Dir.glob(["#{tmpdir}/*.shp", "#{tmpdir}/*.geojson"]).first
           if shape_filename.nil?
             tiff_filename = Dir.glob("#{tmpdir}/*.tif").first
-            ulx, uly, lrx, lry = extent_geotiff tiff_filename # normalized version only
+            ulx, uly, lrx, lry = bounding_box_from_geotiff tiff_filename # normalized version only
           else
-            ulx, uly, lrx, lry = extent_shapefile shape_filename
+            ulx, uly, lrx, lry = bounding_box_from_shapefile shape_filename
           end
           logger.debug [ulx, uly, lrx, lry].join(' -- ')
           [ulx, uly, lrx, lry]
         end
 
-        def check_extent
+        def check_bounding_box
           # Check that we have a valid bounding box
           return if ulx <= lrx && uly >= lry
 

--- a/lib/robots/dor_repo/gis_assembly/generate_mods.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_mods.rb
@@ -90,6 +90,11 @@ module Robots
 
         def find_geometry_type_ogrinfo
           IO.popen("#{Settings.gdal_path}ogrinfo -ro -so -al '#{vector_file}'") do |file|
+            # When GDAL is upgraded to >= 3.7.0, the -json flag can be added to use JSON output instead of parsing text.
+            # json = JSON.parse(file.read)
+            # type = json.dig('layers', 0, 'geometryFields', 0, 'type')
+            # return type&.gsub('3D', '')&.gsub('Multi', '')&.strip
+
             file.readlines.each do |line|
               next unless line =~ /^Geometry:\s+(.*)\s*$/
 

--- a/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
@@ -6,306 +6,573 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
   let(:robot) { described_class.new }
   let(:cocina_object) { build(:dro, id: druid).new(description: original_description) }
 
-  let(:druid) { 'druid:nj441df9572' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object, update: nil) }
 
-  context 'when already EPSG 4326' do
-    let(:original_description) do
-      {
-        title: [
-          {
-            value: 'Afghanistan 2G Mobile Coverage Explorer, 2010'
-          }
-        ],
-        purl: 'https://purl.stanford.edu/nj441df9572',
-        subject: [
-          # {
-          #   value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
-          #   type: 'map coordinates'
-          # }
-        ],
-        form: [
-          {
-            value: 'GeoTIFF',
-            type: 'form'
-          },
-          # {
-          #   value: 'Scale not given.',
-          #   type: 'map scale'
-          # },
-          # {
-          #   value: 'Custom projection',
-          #   type: 'map projection'
-          # },
-          {
-            value: 'EPSG::4326',
-            type: 'map projection'
-            # uri: 'http://opengis.net/def/crs/EPSG/0/4326',
-            # source: {
-            #   code: 'EPSG'
-            # },
-            # displayLabel: 'WGS84'
-          }
-        ],
-        geographic: [
-          {
-            form: [
-              {
-                value: 'image/tiff',
-                type: 'media type',
-                source: {
-                  value: 'IANA media type terms'
-                }
-              },
-              {
-                value: 'GeoTIFF',
-                type: 'data format'
-              },
-              {
-                value: 'Dataset#',
-                type: 'type'
-              }
-            ],
-            subject: [
-              {
-                structuredValue: [
-                  {
-                    value: '56.249996',
-                    type: 'west'
-                  },
-                  {
-                    value: '30.119975',
-                    type: 'south'
-                  },
-                  {
-                    value: '72.368695',
-                    type: 'east'
-                  },
-                  {
-                    value: '38.16636',
-                    type: 'north'
-                  }
-                ],
-                type: 'bounding box coordinates',
-                encoding: {
-                  value: 'decimal'
-                },
-                standard: {
-                  code: 'EPSG:4326'
-                }
-              }
-            ]
-          }
-        ]
-      }
-    end
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(IO).to receive(:popen).and_call_original
+  end
 
-    let(:expected_description) do
-      {
-        title: [
-          {
-            value: 'Afghanistan 2G Mobile Coverage Explorer, 2010'
-          }
-        ],
-        form: [
-          {
-            value: 'GeoTIFF',
-            type: 'form'
-          },
-          # {
-          #   value: 'Scale not given.',
-          #   type: 'map scale'
-          # },
-          # {
-          #   value: 'Custom projection',
-          #   type: 'map projection'
-          # },
-          {
-            value: 'EPSG::4326',
-            type: 'map projection',
-            uri: 'http://opengis.net/def/crs/EPSG/0/4326',
-            source: {
-              code: 'EPSG'
+  context 'when raster' do
+    let(:druid) { 'druid:nj441df9572' }
+
+    context 'when already EPSG 4326' do
+      let(:original_description) do
+        {
+          title: [
+            {
+              value: 'Afghanistan 2G Mobile Coverage Explorer, 2010'
+            }
+          ],
+          purl: 'https://purl.stanford.edu/nj441df9572',
+          subject: [],
+          form: [
+            {
+              value: 'GeoTIFF',
+              type: 'form'
             },
-            displayLabel: 'WGS84'
-          }
-        ],
-        geographic: [
-          {
-            form: [
-              {
-                value: 'image/tiff',
-                type: 'media type',
-                source: {
-                  value: 'IANA media type terms'
-                }
-              },
-              {
-                value: 'GeoTIFF',
-                type: 'data format'
-              },
-              {
-                value: 'Dataset#',
-                type: 'type'
-              }
-            ],
-            subject: [
-              {
-                structuredValue: [
-                  {
-                    value: '56.2499964',
-                    type: 'west'
-                  },
-                  {
-                    value: '30.1199748',
-                    type: 'south'
-                  },
-                  {
-                    value: '72.368695',
-                    type: 'east'
-                  },
-                  {
-                    value: '38.16636',
-                    type: 'north'
+            # {
+            #   value: 'Scale not given.',
+            #   type: 'map scale'
+            # },
+            # {
+            #   value: 'Custom projection',
+            #   type: 'map projection'
+            # },
+            {
+              value: 'EPSG::4326',
+              type: 'map projection'
+              # uri: 'http://opengis.net/def/crs/EPSG/0/4326',
+              # source: {
+              #   code: 'EPSG'
+              # },
+              # displayLabel: 'WGS84'
+            }
+          ],
+          geographic: [
+            {
+              form: [
+                {
+                  value: 'image/tiff',
+                  type: 'media type',
+                  source: {
+                    value: 'IANA media type terms'
                   }
-                ],
-                type: 'bounding box coordinates',
-                standard: {
-                  code: 'EPSG:4326'
                 },
-                encoding: {
-                  value: 'decimal'
+                {
+                  value: 'GeoTIFF',
+                  type: 'data format'
+                },
+                {
+                  value: 'Dataset#',
+                  type: 'type'
                 }
-              }
-            ]
-          }
-        ],
-        note: [
-          # {
-          #   value: 'This layer is presented in the WGS84 coordinate system for web display purposes. Downloadable data are provided in native coordinate system or projection.',
-          #   displayLabel: 'WGS84 Cartographics'
-          # }
-        ],
-        subject: [
-          # {
-          #   value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
-          #   type: 'map coordinates'
-          # }
-        ],
-        purl: 'https://purl.stanford.edu/nj441df9572'
-      }
-    end
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object, update: nil) }
+              ],
+              subject: [
+                {
+                  structuredValue: [
+                    {
+                      value: '56.249996',
+                      type: 'west'
+                    },
+                    {
+                      value: '30.119975',
+                      type: 'south'
+                    },
+                    {
+                      value: '72.368695',
+                      type: 'east'
+                    },
+                    {
+                      value: '38.16636',
+                      type: 'north'
+                    }
+                  ],
+                  type: 'bounding box coordinates',
+                  encoding: {
+                    value: 'decimal'
+                  },
+                  standard: {
+                    code: 'EPSG:4326'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    before do
-      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(IO).to receive(:popen).and_call_original
+      let(:expected_description) do
+        {
+          title: [
+            {
+              value: 'Afghanistan 2G Mobile Coverage Explorer, 2010'
+            }
+          ],
+          form: [
+            {
+              value: 'GeoTIFF',
+              type: 'form'
+            },
+            # {
+            #   value: 'Scale not given.',
+            #   type: 'map scale'
+            # },
+            # {
+            #   value: 'Custom projection',
+            #   type: 'map projection'
+            # },
+            {
+              value: 'EPSG::4326',
+              type: 'map projection',
+              uri: 'http://opengis.net/def/crs/EPSG/0/4326',
+              source: {
+                code: 'EPSG'
+              },
+              displayLabel: 'WGS84'
+            }
+          ],
+          geographic: [
+            {
+              form: [
+                {
+                  value: 'image/tiff',
+                  type: 'media type',
+                  source: {
+                    value: 'IANA media type terms'
+                  }
+                },
+                {
+                  value: 'GeoTIFF',
+                  type: 'data format'
+                },
+                {
+                  value: 'Dataset#',
+                  type: 'type'
+                }
+              ],
+              subject: [
+                {
+                  structuredValue: [
+                    {
+                      value: '56.2499964',
+                      type: 'west'
+                    },
+                    {
+                      value: '30.1199748',
+                      type: 'south'
+                    },
+                    {
+                      value: '72.368695',
+                      type: 'east'
+                    },
+                    {
+                      value: '38.16636',
+                      type: 'north'
+                    }
+                  ],
+                  type: 'bounding box coordinates',
+                  standard: {
+                    code: 'EPSG:4326'
+                  },
+                  encoding: {
+                    value: 'decimal'
+                  }
+                }
+              ]
+            }
+          ],
+          note: [
+            # {
+            #   value: 'This layer is presented in the WGS84 coordinate system for web display purposes. Downloadable data are provided in native coordinate system or projection.',
+            #   displayLabel: 'WGS84 Cartographics'
+            # }
+          ],
+          subject: [
+            # {
+            #   value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
+            #   type: 'map coordinates'
+            # }
+          ],
+          purl: 'https://purl.stanford.edu/nj441df9572'
+        }
+      end
+
+      it 'updates the cocina with the bounding box' do
+        test_perform(robot, druid)
+        expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
+        expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/extractboundingbox_nj441df9572/MCE_AF2G_2010.tif'")
+      end
     end
 
-    it 'updates the cocina with the bounding box' do
-      test_perform(robot, druid)
-      expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
-      expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/extractboundingbox_nj441df9572/MCE_AF2G_2010.tif'")
+    context 'when not already EPSG 4326' do
+      let(:original_description) do
+        { title: [{ value: 'Afghanistan 2G Mobile Coverage Explorer, 2010' }],
+          purl: 'https://purl.stanford.edu/nj441df9572',
+          subject: [
+            {
+              value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
+              type: 'map coordinates'
+            }
+          ],
+          form: [
+            {
+              value: 'GeoTIFF',
+              type: 'form'
+            },
+            # {
+            #   value: 'Scale not given.',
+            #   type: 'map scale'
+            # },
+            {
+              value: 'Custom projection',
+              type: 'map projection'
+            }
+          ],
+          geographic: [
+            {
+              form: [
+                {
+                  value: 'image/tiff',
+                  type: 'media type',
+                  source: {
+                    value: 'IANA media type terms'
+                  }
+                },
+                {
+                  value: 'GeoTIFF',
+                  type: 'data format'
+                },
+                {
+                  value: 'Dataset#',
+                  type: 'type'
+                }
+              ],
+              subject: [
+                # Note that this is not EPSG:4326
+                {
+                  structuredValue: [
+                    {
+                      value: '156.249996',
+                      type: 'west'
+                    },
+                    {
+                      value: '130.119975',
+                      type: 'south'
+                    },
+                    {
+                      value: '172.368695',
+                      type: 'east'
+                    },
+                    {
+                      value: '138.16636',
+                      type: 'north'
+                    }
+                  ],
+                  type: 'bounding box coordinates',
+                  encoding: {
+                    value: 'decimal'
+                  },
+                  standard: {
+                    code: 'EPSG:4327'
+                  }
+                }
+              ]
+            }
+          ] }
+      end
+
+      let(:expected_description) do
+        {
+          title: [
+            {
+              value: 'Afghanistan 2G Mobile Coverage Explorer, 2010'
+            }
+          ],
+          form: [
+            {
+              value: 'GeoTIFF',
+              type: 'form'
+            },
+            {
+              value: 'Custom projection',
+              type: 'map projection'
+            },
+            {
+              value: 'Scale not given.',
+              type: 'map scale'
+            },
+            {
+              value: 'EPSG::4326',
+              type: 'map projection',
+              uri: 'http://opengis.net/def/crs/EPSG/0/4326',
+              source: {
+                code: 'EPSG'
+              },
+              displayLabel: 'WGS84'
+            }
+          ],
+          geographic: [
+            {
+              form: [
+                {
+                  value: 'image/tiff',
+                  type: 'media type',
+                  source: {
+                    value: 'IANA media type terms'
+                  }
+                },
+                {
+                  value: 'GeoTIFF',
+                  type: 'data format'
+                },
+                {
+                  value: 'Dataset#',
+                  type: 'type'
+                }
+              ],
+              subject: [
+                {
+                  structuredValue: [
+                    {
+                      value: '56.2499964',
+                      type: 'west'
+                    },
+                    {
+                      value: '30.1199748',
+                      type: 'south'
+                    },
+                    {
+                      value: '72.368695',
+                      type: 'east'
+                    },
+                    {
+                      value: '38.16636',
+                      type: 'north'
+                    }
+                  ],
+                  type: 'bounding box coordinates',
+                  standard: {
+                    code: 'EPSG:4326'
+                  },
+                  encoding: {
+                    value: 'decimal'
+                  }
+                }
+              ]
+            }
+          ],
+          note: [
+            {
+              value: 'This layer is presented in the WGS84 coordinate system for web display purposes. Downloadable data are provided in native coordinate system or projection.',
+              displayLabel: 'WGS84 Cartographics'
+            }
+          ],
+          subject: [
+            {
+              value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
+              type: 'map coordinates'
+            }
+          ],
+          purl: 'https://purl.stanford.edu/nj441df9572'
+        }
+      end
+
+      it 'updates the cocina with the bounding box' do
+        test_perform(robot, druid)
+        expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
+        expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/extractboundingbox_nj441df9572/MCE_AF2G_2010.tif'")
+      end
     end
   end
 
-  context 'when not already EPSG 4326' do
+  context 'when shapefile' do
+    let(:druid) { 'druid:cc044gt0726' }
     let(:original_description) do
-      { title: [{ value: 'Afghanistan 2G Mobile Coverage Explorer, 2010' }],
-        purl: 'https://purl.stanford.edu/nj441df9572',
-        subject: [
-          {
-            value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
-            type: 'map coordinates'
-          }
-        ],
-        form: [
-          {
-            value: 'GeoTIFF',
-            type: 'form'
-          },
-          # {
-          #   value: 'Scale not given.',
-          #   type: 'map scale'
-          # },
-          {
-            value: 'Custom projection',
-            type: 'map projection'
-          }
-        ],
-        geographic: [
-          {
-            form: [
-              {
-                value: 'image/tiff',
-                type: 'media type',
-                source: {
-                  value: 'IANA media type terms'
-                }
-              },
-              {
-                value: 'GeoTIFF',
-                type: 'data format'
-              },
-              {
-                value: 'Dataset#',
-                type: 'type'
-              }
-            ],
-            subject: [
-              # Note that this is not EPSG:4326
-              {
-                structuredValue: [
-                  {
-                    value: '156.249996',
-                    type: 'west'
-                  },
-                  {
-                    value: '130.119975',
-                    type: 'south'
-                  },
-                  {
-                    value: '172.368695',
-                    type: 'east'
-                  },
-                  {
-                    value: '138.16636',
-                    type: 'north'
-                  }
-                ],
-                type: 'bounding box coordinates',
-                encoding: {
-                  value: 'decimal'
-                },
-                standard: {
-                  code: 'EPSG:4327'
-                }
-              }
-            ]
-          }
-        ] }
-    end
-
-    let(:expected_description) do
       {
         title: [
           {
-            value: 'Afghanistan 2G Mobile Coverage Explorer, 2010'
+            value: 'Important Farmland, San Luis Obispo County, California, 1996'
           }
         ],
         form: [
           {
-            value: 'GeoTIFF',
+            value: 'Geospatial data',
+            type: 'genre',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2011026297',
+            source: {
+              code: 'lcgft'
+            }
+          },
+          {
+            value: 'cartographic dataset',
+            type: 'genre',
+            uri: 'http://rdvocab.info/termList/RDAContentType/1001',
+            source: {
+              code: 'rdacontent'
+            }
+          },
+          {
+            value: 'cartographic',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          },
+          {
+            value: 'software, multimedia',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          },
+          {
+            value: 'Shapefile',
             type: 'form'
           },
           {
-            value: 'Custom projection',
-            type: 'map projection'
+            value: '2.815',
+            type: 'extent'
+          },
+          {
+            value: 'born digital',
+            type: 'digital origin',
+            source: {
+              value: 'MODS digital origin terms'
+            }
           },
           {
             value: 'Scale not given.',
             type: 'map scale'
           },
           {
+            value: 'Custom projection',
+            type: 'map projection'
+          }
+        ],
+        geographic: [
+          {
+            form: [
+              {
+                value: 'application/x-esri-shapefile',
+                type: 'media type',
+                source: {
+                  value: 'IANA media type terms'
+                }
+              },
+              {
+                value: 'Shapefile',
+                type: 'data format'
+              },
+              {
+                value: 'Dataset#Polygon',
+                type: 'type'
+              }
+            ],
+            subject: [
+              {
+                structuredValue: [
+                  {
+                    value: '-120',
+                    type: 'west'
+                  },
+                  {
+                    value: '35',
+                    type: 'south'
+                  },
+                  {
+                    value: '-119',
+                    type: 'east'
+                  },
+                  {
+                    value: '36',
+                    type: 'north'
+                  }
+                ],
+                type: 'bounding box coordinates',
+                standard: {
+                  code: 'EPSG:4326'
+                },
+                encoding: {
+                  value: 'decimal'
+                }
+              },
+              {
+                value: 'San Luis Obispo County (Calif.)',
+                type: 'coverage',
+                valueLanguage: {
+                  code: 'eng'
+                }
+              }
+            ]
+          }
+        ],
+        purl: 'https://purl.stanford.edu/cc044gt0726'
+      }
+    end
+
+    let(:expected_description) do
+      {
+        title: [
+          {
+            value: 'Important Farmland, San Luis Obispo County, California, 1996'
+          }
+        ],
+        form: [
+          {
+            value: 'Geospatial data',
+            type: 'genre',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2011026297',
+            source: {
+              code: 'lcgft'
+            }
+          },
+          {
+            value: 'cartographic dataset',
+            type: 'genre',
+            uri: 'http://rdvocab.info/termList/RDAContentType/1001',
+            source: {
+              code: 'rdacontent'
+            }
+          },
+          {
+            value: 'cartographic',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          },
+          {
+            value: 'software, multimedia',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          },
+          {
+            value: 'Shapefile',
+            type: 'form'
+          },
+          {
+            value: '2.815',
+            type: 'extent'
+          },
+          {
+            value: 'born digital',
+            type: 'digital origin',
+            source: {
+              value: 'MODS digital origin terms'
+            }
+          },
+          {
+            value: 'Scale not given.',
+            type: 'map scale'
+          },
+          {
+            value: 'Custom projection',
+            type: 'map projection'
+          },
+          {
             value: 'EPSG::4326',
             type: 'map projection',
             uri: 'http://opengis.net/def/crs/EPSG/0/4326',
@@ -319,18 +586,18 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
           {
             form: [
               {
-                value: 'image/tiff',
+                value: 'application/x-esri-shapefile',
                 type: 'media type',
                 source: {
                   value: 'IANA media type terms'
                 }
               },
               {
-                value: 'GeoTIFF',
+                value: 'Shapefile',
                 type: 'data format'
               },
               {
-                value: 'Dataset#',
+                value: 'Dataset#Polygon',
                 type: 'type'
               }
             ],
@@ -338,19 +605,19 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
               {
                 structuredValue: [
                   {
-                    value: '56.2499964',
+                    value: '-121.347866',
                     type: 'west'
                   },
                   {
-                    value: '30.1199748',
+                    value: '34.89752',
                     type: 'south'
                   },
                   {
-                    value: '72.368695',
+                    value: '-119.472601',
                     type: 'east'
                   },
                   {
-                    value: '38.16636',
+                    value: '35.795197',
                     type: 'north'
                   }
                 ],
@@ -360,6 +627,13 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
                 },
                 encoding: {
                   value: 'decimal'
+                }
+              },
+              {
+                value: 'San Luis Obispo County (Calif.)',
+                type: 'coverage',
+                valueLanguage: {
+                  code: 'eng'
                 }
               }
             ]
@@ -371,26 +645,14 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
             displayLabel: 'WGS84 Cartographics'
           }
         ],
-        subject: [
-          {
-            value: 'E 56°15ʹ--E 72°22ʹ7ʺ/N 38°9ʹ59ʺ--N 30°7ʹ12ʺ',
-            type: 'map coordinates'
-          }
-        ],
-        purl: 'https://purl.stanford.edu/nj441df9572'
+        purl: 'https://purl.stanford.edu/cc044gt0726'
       }
-    end
-    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object, update: nil) }
-
-    before do
-      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(IO).to receive(:popen).and_call_original
     end
 
     it 'updates the cocina with the bounding box' do
       test_perform(robot, druid)
       expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
-      expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/extractboundingbox_nj441df9572/MCE_AF2G_2010.tif'")
+      expect(IO).to have_received(:popen).with("ogrinfo -ro -so -al '/tmp/extractboundingbox_cc044gt0726/sanluisobispo1996.shp'")
     end
   end
 end

--- a/spec/robots/dor_repo/gis_assembly/generate_mods_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/generate_mods_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::GenerateMods do
     before do
       allow(Settings.geohydra).to receive(:stage).and_return('spec/fixtures/stage')
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(IO).to receive(:popen).and_return(nil)
+      # allow(IO).to receive(:popen).and_return(nil)
     end
 
     context 'when a raster (GeoTIFF)' do
@@ -225,7 +225,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::GenerateMods do
                            identifier: [{ value: 'edu.stanford.purl:vx812cc5548' }] },
           geographic: [{ form: [{ value: 'application/geo+json', type: 'media type', source: { value: 'IANA media type terms' } },
                                 { value: 'GeoJSON', type: 'data format' },
-                                { value: 'Dataset#Polygon', type: 'type' }],
+                                { value: 'Dataset#Point', type: 'type' }],
                          subject: [{ structuredValue: [{ value: '-158.017379', type: 'west' },
                                                        { value: '18.001995', type: 'south' },
                                                        { value: '-65.594769', type: 'east' },


### PR DESCRIPTION
closes #738

## Why was this change made? 🤔
Reading JSON is better than parsing text output.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡

Unit
