### PR TITLE
Add spec for load_raster

### DIFF
--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -43,7 +43,6 @@ module Robots
         def normalizer
           GisRobotSuite::RasterNormalizer.new(logger:, cocina_object:, rootdir:)
         end
-        # end
 
         def rootdir
           @rootdir ||= GisRobotSuite.locate_druid_path bare_druid, type: :workspace

--- a/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
@@ -3,36 +3,101 @@
 require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
-  let(:druid) { 'bc123df4567' }
-  let(:rootdir) { '/dor/workspace/druid:bc123df4567' }
-  let(:tiffn) { 'bc123df4567.tif' }
+  let(:druid) { "druid:#{bare_druid}" }
+  let(:bare_druid) { 'bb021mm7809' }
+  let(:tiffn) { 'MCE_FI2G_2014.tif' }
   let(:path) { '/geotiff' }
-  let(:cmd) { "rsync -v '#{tiffn}' #{path}/bc123df4567.tif" }
-  let(:cmd_aux) { "rsync -v '#{tiffn}'.aux.xml #{path}/bc123df4567.tif.aux.xml" }
+  let(:cmd) { "rsync -v '#{tiffn}' #{path}/#{bare_druid}.tif" }
+  let(:cmd_aux) { "rsync -v '#{tiffn}'.aux.xml #{path}/#{bare_druid}.tif.aux.xml" }
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
-  let(:cocina_object) do
-    dro = build(:dro)
-    dro.new(description: dro.description.new(geographic: [
-                                               { form: [{ type: 'media type', value: media_type }, { type: 'data format', value: 'GeoTIFF' }] }
-                                             ]))
+  let(:cocina_object) { build(:dro, id: druid).new(description:) }
+  let(:description) do
+    {
+      title: [
+        {
+          value: 'Finland 2G Mobile Coverage Explorer, 2014'
+        }
+      ],
+      geographic: [
+        {
+          form: [
+            {
+              value: media_type,
+              type: 'media type',
+              source: {
+                value: 'IANA media type terms'
+              }
+            },
+            {
+              value: 'GeoTIFF',
+              type: 'data format'
+            },
+            {
+              value: 'Dataset#',
+              type: 'type'
+            }
+          ],
+          subject: [
+            {
+              structuredValue: [
+                {
+                  value: '16.1179474',
+                  type: 'west'
+                },
+                {
+                  value: '59.2022116',
+                  type: 'south'
+                },
+                {
+                  value: '32.2367687',
+                  type: 'east'
+                },
+                {
+                  value: '70.6126121',
+                  type: 'north'
+                }
+              ],
+              type: 'bounding box coordinates',
+              standard: {
+                code: 'EPSG:4326'
+              },
+              encoding: {
+                value: 'decimal'
+              }
+            },
+            {
+              value: 'Finland',
+              type: 'coverage',
+              valueLanguage: {
+                code: 'eng'
+              }
+            }
+          ]
+        }
+      ],
+      purl: "https://purl.stanford.edu/#{bare_druid}"
+    }
   end
 
   before do
-    allow(Dir).to receive(:chdir).with('spec/fixtures/workspace/bc/123/df/4567/bc123df4567')
-    allow(Dir).to receive(:glob).with('*.tif').and_return([tiffn])
     allow(robot).to receive(:system).with(cmd, exception: true)
     allow(robot).to receive(:system).with(cmd_aux, exception: true)
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(Kernel).to receive(:system).and_call_original
   end
 
   context 'when the object is not a raster' do
     let(:media_type) { 'application/x-esri-shapefile' }
+    let(:normalizer) { instance_double(GisRobotSuite::RasterNormalizer, with_normalized: true) }
+
+    before { allow(GisRobotSuite::RasterNormalizer).to receive(:new).and_return(normalizer) }
 
     it 'does nothing' do
       test_perform(robot, druid)
+      expect(normalizer).not_to have_received(:with_normalized)
       expect(robot).not_to have_received(:system).with(cmd, exception: true)
       expect(robot).not_to have_received(:system).with(cmd_aux, exception: true)
     end

--- a/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
+  let(:druid) { 'bc123df4567' }
+  let(:rootdir) { '/dor/workspace/druid:bc123df4567' }
+  let(:tiffn) { 'bc123df4567.tif' }
+  let(:path) { '/geotiff' }
+  let(:cmd) { "rsync -v '#{tiffn}' #{path}/bc123df4567.tif" }
+  let(:cmd_aux) { "rsync -v '#{tiffn}'.aux.xml #{path}/bc123df4567.tif.aux.xml" }
+  let(:robot) { described_class.new }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
+  let(:cocina_object) do
+    dro = build(:dro)
+    dro.new(description: dro.description.new(geographic: [
+                                               { form: [{ type: 'media type', value: media_type }, { type: 'data format', value: 'GeoTIFF' }] }
+                                             ]))
+  end
+
+  before do
+    allow(Dir).to receive(:chdir).with('spec/fixtures/workspace/bc/123/df/4567/bc123df4567')
+    allow(Dir).to receive(:glob).with('*.tif').and_return([tiffn])
+    allow(robot).to receive(:system).with(cmd, exception: true)
+    allow(robot).to receive(:system).with(cmd_aux, exception: true)
+    allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+  end
+
+  context 'when the object is not a raster' do
+    let(:media_type) { 'application/x-esri-shapefile' }
+
+    it 'does nothing' do
+      test_perform(robot, druid)
+      expect(robot).not_to have_received(:system).with(cmd, exception: true)
+      expect(robot).not_to have_received(:system).with(cmd_aux, exception: true)
+    end
+  end
+
+  context 'when the object is a raster' do
+    let(:media_type) { 'image/tiff' }
+
+    it 'executes system commands to load raster' do
+      test_perform(robot, druid)
+      expect(robot).to have_received(:system).with(cmd, exception: true)
+      expect(robot).to have_received(:system).with(cmd_aux, exception: true)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #758 - adds a spec for load raster

~~Blocked by https://github.com/sul-dlss/gis-robot-suite/pull/818 ... we need that first, then just take the best parts of the load_raster_spec
the changes in this PR to the load_raster robot can likely all be tossed~~

## How was this change tested? 🤨

CI

