### PR TITLE
show appropriate error when preview.jpg missing

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/generate_structural.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_structural.rb
@@ -61,6 +61,8 @@ module Robots
         end
 
         def preview_objectfile
+          raise "Missing preview file: #{preview_objectfile_path}" unless File.exist?(preview_objectfile_path)
+
           @preview_objectfile ||= Assembly::ObjectFile.new(preview_objectfile_path)
         end
 

--- a/spec/robots/dor_repo/gis_assembly/generate_structural_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/generate_structural_spec.rb
@@ -381,6 +381,14 @@ RSpec.describe Robots::DorRepo::GisAssembly::GenerateStructural do
       end
     end
 
+    context 'without preview.jpg file' do
+      let(:druid) { 'druid:bh432xr2264' } # druid with no preview.jpg in staging fixture area
+
+      it 'raises an exception' do
+        expect { test_perform(robot, druid) }.to raise_error(/Missing preview file/)
+      end
+    end
+
     context 'with raster data' do
       let(:druid) { 'druid:rc709sz0113' }
       let(:expected_file_access) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #840 - raise an exception if the preview.jpg file is missing, so we can get a better error message.

Presumes that each GIS object must have a preview.jpg (true?)

## How was this change tested? 🤨

new test