### PR TITLE
Make sure vector? and raster? use the same pattern.

### DIFF
--- a/lib/gis_robot_suite.rb
+++ b/lib/gis_robot_suite.rb
@@ -66,8 +66,10 @@ module GisRobotSuite # rubocop:disable Metrics/ModuleLength
     end
   end
 
+  VECTOR_TYPES = %w[application/x-esri-shapefile application/geo+json].freeze
+
   def self.vector?(cocina_object)
-    ['application/x-esri-shapefile', 'application/geo+json'].include? media_type(cocina_object)
+    VECTOR_TYPES.include? media_type(cocina_object)
   end
 
   RASTER_TYPES = %w[image/tiff].freeze


### PR DESCRIPTION
## Why was this change made? 🤔

Small PR to make the `vector?` method follow the pattern of the `raster?` method just below it.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


