### PR TITLE
LoadRaster and LoadVector: refactor to remove Dir.chdir calls, and to improve maintainability

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,4 @@
 ---
-# The concurrency is set to 1 since Dir.chdir is used, which is not thread safe.
-# See https://bugs.ruby-lang.org/issues/15661
 :concurrency: 1
 :queues:
   - gisAssemblyWF_default

--- a/lib/gis_robot_suite/vector_normalizer.rb
+++ b/lib/gis_robot_suite/vector_normalizer.rb
@@ -36,8 +36,7 @@ module GisRobotSuite
             "'#{shp_filename}' #{schema}.#{bare_druid} " \
             "> '#{sql_filename}' 2> '#{stderr_filename}'"
       logger.debug "Running: #{cmd}"
-      success = system(cmd, exception: true)
-      raise "normalize-vector: #{bare_druid} cannot convert Shapefile to PostGIS: #{File.open(stderr_filename).readlines}" unless success
+      system(cmd, exception: true)
       raise "normalize-vector: #{bare_druid} shp2pgsql generated no SQL?" unless File.size?(sql_filename)
     end
 

--- a/lib/gis_robot_suite/vector_normalizer.rb
+++ b/lib/gis_robot_suite/vector_normalizer.rb
@@ -29,17 +29,6 @@ module GisRobotSuite
       FileUtils.rm_rf tmpdir
     end
 
-    def run_shp2pgsql(projection, encoding, shp_filename, schema, sql_filename, stderr_filename)
-      # XXX: Perhaps put the .sql data into the content directory as .zip for derivative
-      # XXX: -G for the geography column causes some issues with GeoServer
-      cmd = "shp2pgsql -s #{projection} -d -D -I -W #{encoding} " \
-            "'#{shp_filename}' #{schema}.#{bare_druid} " \
-            "> '#{sql_filename}' 2> '#{stderr_filename}'"
-      logger.debug "Running: #{cmd}"
-      system(cmd, exception: true)
-      raise "normalize-vector: #{bare_druid} shp2pgsql generated no SQL?" unless File.size?(sql_filename)
-    end
-
     private
 
     attr_reader :logger, :bare_druid, :rootdir

--- a/lib/gis_robot_suite/vector_normalizer.rb
+++ b/lib/gis_robot_suite/vector_normalizer.rb
@@ -29,16 +29,16 @@ module GisRobotSuite
       FileUtils.rm_rf tmpdir
     end
 
-    def run_shp2pgsql(projection, encoding, shpfn, schema, sqlfn, errfn)
+    def run_shp2pgsql(projection, encoding, shp_filename, schema, sql_filename, stderr_filename)
       # XXX: Perhaps put the .sql data into the content directory as .zip for derivative
       # XXX: -G for the geography column causes some issues with GeoServer
       cmd = "shp2pgsql -s #{projection} -d -D -I -W #{encoding} " \
-            "'#{shpfn}' #{schema}.#{bare_druid} " \
-            "> '#{sqlfn}' 2> '#{errfn}'"
+            "'#{shp_filename}' #{schema}.#{bare_druid} " \
+            "> '#{sql_filename}' 2> '#{stderr_filename}'"
       logger.debug "Running: #{cmd}"
       success = system(cmd, exception: true)
-      raise "normalize-vector: #{bare_druid} cannot convert Shapefile to PostGIS: #{File.open(errfn).readlines}" unless success
-      raise "normalize-vector: #{bare_druid} shp2pgsql generated no SQL?" unless File.size?(sqlfn)
+      raise "normalize-vector: #{bare_druid} cannot convert Shapefile to PostGIS: #{File.open(stderr_filename).readlines}" unless success
+      raise "normalize-vector: #{bare_druid} shp2pgsql generated no SQL?" unless File.size?(sql_filename)
     end
 
     private

--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -19,21 +19,21 @@ module Robots
 
           normalizer.with_normalized do |tmpdir|
             Dir.chdir(tmpdir) do
-              tiffn = Dir.glob('*.tif').first
-              raise "load-raster: #{bare_druid} cannot locate GeoTIFF: #{tmpdir}" if tiffn.nil?
+              tif_filename = Dir.glob('*.tif').first
+              raise "load-raster: #{bare_druid} cannot locate GeoTIFF: #{tmpdir}" if tif_filename.nil?
 
               # copy to geoserver storage
-              path = if Settings.geohydra.geotiff.host == 'localhost'
-                       Settings.geohydra.geotiff.dir
-                     else
-                       [Settings.geohydra.geotiff.host, Settings.geohydra.geotiff.dir].join(':')
-                     end
-              cmd = "rsync -v '#{tiffn}' #{path}/#{bare_druid}.tif"
+              destination_path = if Settings.geohydra.geotiff.host == 'localhost'
+                                   Settings.geohydra.geotiff.dir
+                                 else
+                                   [Settings.geohydra.geotiff.host, Settings.geohydra.geotiff.dir].join(':')
+                                 end
+              cmd = "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif"
               logger.debug "Running: #{cmd}"
               system(cmd, exception: true)
 
-              # copy statistics files (produced by CopyData#compute_statistics, as of Feb 2024)
-              cmd = "rsync -v '#{tiffn}'.aux.xml #{path}/#{bare_druid}.tif.aux.xml"
+              # copy statistics files (produced by RasterNormalizer#compute_statistics, as of March 2024)
+              cmd = "rsync -v '#{tif_filename}'.aux.xml #{destination_path}/#{bare_druid}.tif.aux.xml"
               logger.debug "Running: #{cmd}"
               system(cmd, exception: true)
             end

--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -18,25 +18,23 @@ module Robots
           end
 
           normalizer.with_normalized do |tmpdir|
-            Dir.chdir(tmpdir) do
-              tif_filename = Dir.glob('*.tif').first
-              raise "load-raster: #{bare_druid} cannot locate GeoTIFF: #{tmpdir}" if tif_filename.nil?
+            tif_filename = Dir.glob("#{tmpdir}/*.tif").first
+            raise "load-raster: #{bare_druid} cannot locate GeoTIFF: #{tmpdir}" if tif_filename.nil?
 
-              # copy to geoserver storage
-              destination_path = if Settings.geohydra.geotiff.host == 'localhost'
-                                   Settings.geohydra.geotiff.dir
-                                 else
-                                   [Settings.geohydra.geotiff.host, Settings.geohydra.geotiff.dir].join(':')
-                                 end
-              cmd = "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif"
-              logger.debug "Running: #{cmd}"
-              system(cmd, exception: true)
+            # copy to geoserver storage
+            destination_path = if Settings.geohydra.geotiff.host == 'localhost'
+                                 Settings.geohydra.geotiff.dir
+                               else
+                                 [Settings.geohydra.geotiff.host, Settings.geohydra.geotiff.dir].join(':')
+                               end
+            cmd = "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif"
+            logger.debug "Running: #{cmd}"
+            system(cmd, exception: true)
 
-              # copy statistics files (produced by RasterNormalizer#compute_statistics, as of March 2024)
-              cmd = "rsync -v '#{tif_filename}'.aux.xml #{destination_path}/#{bare_druid}.tif.aux.xml"
-              logger.debug "Running: #{cmd}"
-              system(cmd, exception: true)
-            end
+            # copy statistics files (produced by RasterNormalizer#compute_statistics, as of March 2024)
+            cmd = "rsync -v '#{tif_filename}'.aux.xml #{destination_path}/#{bare_druid}.tif.aux.xml"
+            logger.debug "Running: #{cmd}"
+            system(cmd, exception: true)
           end
         end
 

--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -21,13 +21,6 @@ module Robots
 
           normalizer.with_normalized do |tmpdir|
             schema = Settings.geohydra.postgis.schema || 'druid'
-            # encoding =  # XXX: these are hardcoded encodings for certain druids -- these should be read from the metadata somewhere
-            #   case druid
-            #   when 'bt348dh6363', 'cc936tf6277'
-            #     'LATIN1'
-            #   else
-            #     'UTF-8'
-            #   end
 
             # sniff out shapefile from extraction
             shp_filename = Dir.glob("#{tmpdir}/*.shp").first
@@ -37,6 +30,7 @@ module Robots
             logger.debug "load-vector: #{bare_druid} is working on Shapefile: #{shp_filename}"
 
             # first try decoding with UTF-8 and if that fails use LATIN1
+            # see also https://github.com/sul-dlss/gis-robot-suite/issues/850
             begin
               run_shp2pgsql('4326', 'UTF-8', shp_filename, schema, sql_filename, stderr_filename)
             rescue RuntimeError => e

--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -39,7 +39,9 @@ module Robots
             # first try decoding with UTF-8 and if that fails use LATIN1
             begin
               normalizer.run_shp2pgsql('4326', 'UTF-8', shp_filename, schema, sql_filename, stderr_filename)
-            rescue RuntimeError
+            rescue RuntimeError => e
+              logger.warn("#{druid} -- fell through to LATIN1 encoding after calling normalizer.run_shp2pgsql with " \
+                          "UTF-8 encoding and encountering error: #{e.message}; #{e.backtrace.join('; ')}")
               normalizer.run_shp2pgsql('4326', 'LATIN1', shp_filename, schema, sql_filename, stderr_filename)
             end
 

--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -31,21 +31,21 @@ module Robots
 
             # sniff out shapefile from extraction
             Dir.chdir(tmpdir)
-            shpfn = Dir.glob('*.shp').first
-            sqlfn = shpfn.gsub(/\.shp$/, '.sql')
-            errfn = 'shp2pgsql.err'
-            logger.debug "load-vector: #{bare_druid} is working on Shapefile: #{shpfn}"
+            shp_filename = Dir.glob('*.shp').first
+            sql_filename = shp_filename.gsub(/\.shp$/, '.sql')
+            stderr_filename = 'shp2pgsql.err'
+            logger.debug "load-vector: #{bare_druid} is working on Shapefile: #{shp_filename}"
 
             # first try decoding with UTF-8 and if that fails use LATIN1
             begin
-              normalizer.run_shp2pgsql('4326', 'UTF-8', shpfn, schema, sqlfn, errfn)
+              normalizer.run_shp2pgsql('4326', 'UTF-8', shp_filename, schema, sql_filename, stderr_filename)
             rescue RuntimeError
-              normalizer.run_shp2pgsql('4326', 'LATIN1', shpfn, schema, sqlfn, errfn)
+              normalizer.run_shp2pgsql('4326', 'LATIN1', shp_filename, schema, sql_filename, stderr_filename)
             end
 
             # Load the data into PostGIS
             cmd = 'psql --no-psqlrc --no-password --quiet ' \
-                  "--file='#{sqlfn}' "
+                  "--file='#{sql_filename}' "
             logger.debug "Running: #{cmd}"
             system(cmd, exception: true)
           end

--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -30,10 +30,10 @@ module Robots
             #   end
 
             # sniff out shapefile from extraction
-            Dir.chdir(tmpdir)
-            shp_filename = Dir.glob('*.shp').first
+            shp_filename = Dir.glob("#{tmpdir}/*.shp").first
             sql_filename = shp_filename.gsub(/\.shp$/, '.sql')
-            stderr_filename = 'shp2pgsql.err'
+            stderr_filename = "#{tmpdir}/shp2pgsql.err"
+
             logger.debug "load-vector: #{bare_druid} is working on Shapefile: #{shp_filename}"
 
             # first try decoding with UTF-8 and if that fails use LATIN1

--- a/spec/gis_robot_suite/vector_normalizer_spec.rb
+++ b/spec/gis_robot_suite/vector_normalizer_spec.rb
@@ -43,4 +43,24 @@ RSpec.describe GisRobotSuite::VectorNormalizer do
       )
     end
   end
+
+  describe '#run_shp2pgsql' do
+    let(:projection) { '4326' }
+    let(:encoding) { 'UTF-8' }
+    let(:bare_druid) { 'cc044gt0726' }
+    let(:shp_filename) { "#{tmpdir}/sanluisobispo1996.shp" }
+    let(:sql_filename) { "#{tmpdir}/sanluisobispo1996.sql" }
+    let(:stderr_filename) { "#{tmpdir}/shp2pgsql.err" }
+    let(:cmd) { "shp2pgsql -s #{projection} -d -D -I -W #{encoding} '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
+
+    before do
+      allow(normalizer).to receive(:system).with(cmd, exception: true).and_return(true)
+      allow(File).to receive(:size?).with(sql_filename).and_return('123')
+    end
+
+    it 'runs the psql command with the given parameters' do
+      normalizer.run_shp2pgsql(projection, encoding, shp_filename, 'druid', sql_filename, stderr_filename)
+      expect(normalizer).to have_received(:system).with(cmd, exception: true)
+    end
+  end
 end

--- a/spec/gis_robot_suite/vector_normalizer_spec.rb
+++ b/spec/gis_robot_suite/vector_normalizer_spec.rb
@@ -43,24 +43,4 @@ RSpec.describe GisRobotSuite::VectorNormalizer do
       )
     end
   end
-
-  describe '#run_shp2pgsql' do
-    let(:projection) { '4326' }
-    let(:encoding) { 'UTF-8' }
-    let(:bare_druid) { 'cc044gt0726' }
-    let(:shp_filename) { "#{tmpdir}/sanluisobispo1996.shp" }
-    let(:sql_filename) { "#{tmpdir}/sanluisobispo1996.sql" }
-    let(:stderr_filename) { "#{tmpdir}/shp2pgsql.err" }
-    let(:cmd) { "shp2pgsql -s #{projection} -d -D -I -W #{encoding} '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
-
-    before do
-      allow(normalizer).to receive(:system).with(cmd, exception: true).and_return(true)
-      allow(File).to receive(:size?).with(sql_filename).and_return('123')
-    end
-
-    it 'runs the psql command with the given parameters' do
-      normalizer.run_shp2pgsql(projection, encoding, shp_filename, 'druid', sql_filename, stderr_filename)
-      expect(normalizer).to have_received(:system).with(cmd, exception: true)
-    end
-  end
 end

--- a/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
   let(:druid) { "druid:#{bare_druid}" }
   let(:bare_druid) { 'bb021mm7809' }
-  let(:tiffn) { 'MCE_FI2G_2014.tif' }
-  let(:path) { '/geotiff' }
-  let(:cmd) { "rsync -v '#{tiffn}' #{path}/#{bare_druid}.tif" }
-  let(:cmd_aux) { "rsync -v '#{tiffn}'.aux.xml #{path}/#{bare_druid}.tif.aux.xml" }
+  let(:tif_filename) { 'MCE_FI2G_2014.tif' }
+  let(:destination_path) { '/geotiff' }
+  let(:cmd_tif_sync) { "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif" }
+  let(:cmd_aux_sync) { "rsync -v '#{tif_filename}'.aux.xml #{destination_path}/#{bare_druid}.tif.aux.xml" }
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
@@ -82,8 +82,8 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
   end
 
   before do
-    allow(robot).to receive(:system).with(cmd, exception: true)
-    allow(robot).to receive(:system).with(cmd_aux, exception: true)
+    allow(robot).to receive(:system).with(cmd_tif_sync, exception: true)
+    allow(robot).to receive(:system).with(cmd_aux_sync, exception: true)
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(Kernel).to receive(:system).and_call_original
@@ -98,8 +98,8 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
     it 'does nothing' do
       test_perform(robot, druid)
       expect(normalizer).not_to have_received(:with_normalized)
-      expect(robot).not_to have_received(:system).with(cmd, exception: true)
-      expect(robot).not_to have_received(:system).with(cmd_aux, exception: true)
+      expect(robot).not_to have_received(:system).with(cmd_tif_sync, exception: true)
+      expect(robot).not_to have_received(:system).with(cmd_aux_sync, exception: true)
     end
   end
 
@@ -108,8 +108,8 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
 
     it 'executes system commands to load raster' do
       test_perform(robot, druid)
-      expect(robot).to have_received(:system).with(cmd, exception: true)
-      expect(robot).to have_received(:system).with(cmd_aux, exception: true)
+      expect(robot).to have_received(:system).with(cmd_tif_sync, exception: true)
+      expect(robot).to have_received(:system).with(cmd_aux_sync, exception: true)
     end
   end
 end

--- a/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
   let(:druid) { "druid:#{bare_druid}" }
   let(:bare_druid) { 'bb021mm7809' }
-  let(:tif_filename) { 'MCE_FI2G_2014.tif' }
+  let(:tif_filename) { "/tmp/normalizeraster_#{bare_druid}/MCE_FI2G_2014.tif" }
   let(:destination_path) { '/geotiff' }
   let(:cmd_tif_sync) { "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif" }
   let(:cmd_aux_sync) { "rsync -v '#{tif_filename}'.aux.xml #{destination_path}/#{bare_druid}.tif.aux.xml" }

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   let(:shp_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.shp" }
   let(:sql_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.sql" }
   let(:stderr_filename) { "#{normalizer_tmpdir}/shp2pgsql.err" }
-  let(:cmd) { "psql --no-psqlrc --no-password --quiet --file='#{sql_filename}' " }
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
@@ -84,7 +83,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   end
 
   before do
-    allow(robot).to receive(:system).with(cmd, exception: true)
+    allow(robot).to receive(:system)
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(GisRobotSuite::VectorNormalizer).to receive(:new).and_return(normalizer)
@@ -97,7 +96,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
     it 'does nothing' do
       test_perform(robot, druid)
       expect(normalizer).not_to have_received(:with_normalized)
-      expect(robot).not_to have_received(:system).with(cmd, exception: true)
+      expect(robot).not_to have_received(:system)
     end
   end
 
@@ -106,6 +105,8 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
     let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil) }
     let(:rootdir) { GisRobotSuite.locate_druid_path bare_druid, type: :workspace }
     let(:normalizer) { GisRobotSuite::VectorNormalizer.new(logger:, bare_druid:, rootdir:) }
+    let(:cmd_psql) { "psql --no-psqlrc --no-password --quiet --file='#{sql_filename}' " }
+    let(:cmd_shp2pgsql) { "shp2pgsql -s 4326 -d -D -I -W UTF-8 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
     let(:wkt) do
       'GEOGCS["WGS 84", DATUM["WGS_1984", SPHEROID["WGS 84",6378137,298.257223563, AUTHORITY["EPSG","7030"]], AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich",0, AUTHORITY["EPSG","8901"]], UNIT["degree",0.0174532925199433, AUTHORITY["EPSG","9122"]], AUTHORITY["EPSG","4326"]]' # rubocop:disable Layout/LineLength
     end
@@ -114,35 +115,38 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
       stub_request(:get, 'https://spatialreference.org/ref/epsg/4326/prettywkt/')
         .to_return(status: 200, body: wkt, headers: {})
       allow(robot).to receive(:normalizer).and_return(normalizer)
-      allow(normalizer).to receive_messages(cleanup: true, run_shp2pgsql: true)
+      allow(normalizer).to receive_messages(cleanup: true)
+      allow(File).to receive(:size?).and_call_original
+      allow(File).to receive(:size?).with(sql_filename).and_return('123')
     end
 
     it 'executes system commands to load vector' do
       test_perform(robot, druid)
-      expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'UTF-8', shp_filename, 'druid', sql_filename, stderr_filename)
       expect(normalizer).to have_received(:cleanup)
-      expect(robot).to have_received(:system).with(cmd, exception: true)
+      expect(robot).to have_received(:system).with(cmd_shp2pgsql, exception: true)
+      expect(robot).to have_received(:system).with(cmd_psql, exception: true)
     end
 
     context 'when decoding UTF-8 fails' do
       let(:decoding_err_msg) { 'Could not decode UTF-8 for some reason 🤷' }
+      let(:cmd_shp2pgsql_retry) { "shp2pgsql -s 4326 -d -D -I -W LATIN1 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
 
       before do
         allow(robot.logger).to receive(:warn)
-        allow(normalizer).to receive(:run_shp2pgsql) do |_projection, encoding, _shp_filename, _schema, _sql_filename, _stderr_filename|
-          raise decoding_err_msg if encoding == 'UTF-8'
+        allow(robot).to receive(:system) do |cmd|
+          raise decoding_err_msg if cmd.include?('-W UTF-8')
         end
       end
 
-      it 'logs a warning and re-tries run_shp2pgsql with LATIN1 encoding' do
+      it 'logs a warning and re-tries shp2pgsql with LATIN1 encoding' do
         expect { test_perform(robot, druid) }.not_to raise_error
 
-        expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'UTF-8', shp_filename, 'druid', sql_filename, stderr_filename)
+        expect(robot).to have_received(:system).with(cmd_shp2pgsql, exception: true)
 
-        base_err_msg = 'fell through to LATIN1 encoding after calling normalizer.run_shp2pgsql with UTF-8 encoding and encountering error'
+        base_err_msg = 'fell through to LATIN1 encoding after calling run_shp2pgsql with UTF-8 encoding and encountering error'
         backtrace_regex = "#{__FILE__}:\\d+.*in .block.*; "
         expect(robot.logger).to have_received(:warn).with(/#{druid} -- #{base_err_msg}: #{decoding_err_msg}; .*#{backtrace_regex}/)
-        expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'LATIN1', shp_filename, 'druid', sql_filename, stderr_filename)
+        expect(robot).to have_received(:system).with(cmd_shp2pgsql_retry, exception: true)
       end
     end
   end

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -5,7 +5,10 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   let(:druid) { "druid:#{bare_druid}" }
   let(:bare_druid) { 'cc044gt0726' }
-  let(:cmd) { "psql --no-psqlrc --no-password --quiet --file='sanluisobispo1996.sql' " }
+  let(:shp_filename) { 'sanluisobispo1996.shp' }
+  let(:sql_filename) { 'sanluisobispo1996.sql' }
+  let(:stderr_filename) { 'shp2pgsql.err' }
+  let(:cmd) { "psql --no-psqlrc --no-password --quiet --file='#{sql_filename}' " }
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
@@ -115,7 +118,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
 
     it 'executes system commands to load vector' do
       test_perform(robot, druid)
-      expect(normalizer).to have_received(:run_shp2pgsql)
+      expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'UTF-8', shp_filename, 'druid', sql_filename, stderr_filename)
       expect(normalizer).to have_received(:cleanup)
       expect(robot).to have_received(:system).with(cmd, exception: true)
     end

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
 
   context 'when the object is a vector' do
     let(:media_type) { 'application/x-esri-shapefile' }
-    let(:logger) { instance_double(Logger, debug: nil, info: nil) }
+    let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil) }
     let(:rootdir) { GisRobotSuite.locate_druid_path bare_druid, type: :workspace }
     let(:normalizer) { GisRobotSuite::VectorNormalizer.new(logger:, bare_druid:, rootdir:) }
     let(:wkt) do
@@ -114,6 +114,11 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
         .to_return(status: 200, body: wkt, headers: {})
       allow(robot).to receive(:normalizer).and_return(normalizer)
       allow(normalizer).to receive_messages(cleanup: true, run_shp2pgsql: true)
+      @pwd = Dir.pwd
+    end
+
+    after do
+      Dir.chdir(@pwd) # rubocop:disable RSpec/InstanceVariable
     end
 
     it 'executes system commands to load vector' do
@@ -121,6 +126,28 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
       expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'UTF-8', shp_filename, 'druid', sql_filename, stderr_filename)
       expect(normalizer).to have_received(:cleanup)
       expect(robot).to have_received(:system).with(cmd, exception: true)
+    end
+
+    context 'when decoding UTF-8 fails' do
+      let(:decoding_err_msg) { 'Could not decode UTF-8 for some reason 🤷' }
+
+      before do
+        allow(robot.logger).to receive(:warn)
+        allow(normalizer).to receive(:run_shp2pgsql) do |_projection, encoding, _shp_filename, _schema, _sql_filename, _stderr_filename|
+          raise decoding_err_msg if encoding == 'UTF-8'
+        end
+      end
+
+      it 'logs a warning and re-tries run_shp2pgsql with LATIN1 encoding' do
+        expect { test_perform(robot, druid) }.not_to raise_error
+
+        expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'UTF-8', shp_filename, 'druid', sql_filename, stderr_filename)
+
+        base_err_msg = 'fell through to LATIN1 encoding after calling normalizer.run_shp2pgsql with UTF-8 encoding and encountering error'
+        backtrace_regex = "#{__FILE__}:\\d+.*in .block.*; "
+        expect(robot.logger).to have_received(:warn).with(/#{druid} -- #{base_err_msg}: #{decoding_err_msg}; .*#{backtrace_regex}/)
+        expect(normalizer).to have_received(:run_shp2pgsql).with('4326', 'LATIN1', shp_filename, 'druid', sql_filename, stderr_filename)
+      end
     end
   end
 end

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -5,9 +5,10 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   let(:druid) { "druid:#{bare_druid}" }
   let(:bare_druid) { 'cc044gt0726' }
-  let(:shp_filename) { 'sanluisobispo1996.shp' }
-  let(:sql_filename) { 'sanluisobispo1996.sql' }
-  let(:stderr_filename) { 'shp2pgsql.err' }
+  let(:normalizer_tmpdir) { "/tmp/normalizevector_#{bare_druid}" }
+  let(:shp_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.shp" }
+  let(:sql_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.sql" }
+  let(:stderr_filename) { "#{normalizer_tmpdir}/shp2pgsql.err" }
   let(:cmd) { "psql --no-psqlrc --no-password --quiet --file='#{sql_filename}' " }
   let(:robot) { described_class.new }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
@@ -114,11 +115,6 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
         .to_return(status: 200, body: wkt, headers: {})
       allow(robot).to receive(:normalizer).and_return(normalizer)
       allow(normalizer).to receive_messages(cleanup: true, run_shp2pgsql: true)
-      @pwd = Dir.pwd
-    end
-
-    after do
-      Dir.chdir(@pwd) # rubocop:disable RSpec/InstanceVariable
     end
 
     it 'executes system commands to load vector' do


### PR DESCRIPTION
## Why was this change made? 🤔

* fix #827
* while in the code directly relevant to that ticket, do some refactoring and comment cleanup to (hopefully) make things more maintainable.  and shore up test coverage as well.

## How was this change tested? 🤨

- [x] CI
- [x] integration tests (`gis_accessioning_spec.rb` and `preassembly_gis_accessioning_spec.rb`)
  - https://argo-stage.stanford.edu/view/hj013px5098 and https://argo-stage.stanford.edu/view/bp296xj0892
- [x] manual test with a raster file, since integration tests only use a shapefile, and thus only exercise `gisDeliveryWF` `load-vector`, and not `gisDeliveryWF` `load-raster`
  - add (or at least ticket adding) an integration test that will add `gisDeliveryWF` `load-raster` coverage
    - ticketed as https://github.com/sul-dlss/infrastructure-integration-test/issues/699

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


