### PR TITLE
Add a step to the end of gisDeliveryWF that cleans the stage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Kim Durante &amp; Darren Hardy (2015) Discovery, Management, and Preservation of
 * `reset-geowebcache` :: Reset GeoWebCache for the layer
 * `finish-gis-delivery-workflow` :: Connect to public and restricted GeoServers to verify layer
 * `reload-geoserver` :: Automatically reload the GeoServer
+* `metadata-cleanup` :: Remove the staging druid tree for the working druid
 * `start-accession-workflow` :: Start accessionWF
 
 Data Wrangling

--- a/bin/run_delivery
+++ b/bin/run_delivery
@@ -12,6 +12,7 @@ for s in \
   reset-geowebcache \
   finish-gis-delivery-workflow \
   reload-geoserver \
+  metadata-cleanup \
   start-accession-workflow \
   ; do
   bundle exec run_robot dor:gisDeliveryWF:$s -d $druid

--- a/lib/robots/dor_repo/gis_delivery/metadata_cleanup.rb
+++ b/lib/robots/dor_repo/gis_delivery/metadata_cleanup.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module Robots
+  module DorRepo
+    module GisDelivery
+      class MetadataCleanup < Base
+        def initialize
+          super('gisDeliveryWF', 'metadata-cleanup')
+        end
+
+        def perform_work
+          logger.debug "metadata-cleanup working on #{bare_druid}"
+          stage_dir = GisRobotSuite.locate_druid_path bare_druid, type: :stage
+          content_dir = File.join(stage_dir, 'content')
+          FileUtils.rm_f Dir.glob("#{content_dir}/*") # remove all the files (not directories)
+          remove_empty_druid_path_parts(content_dir) if File.directory?(content_dir)
+        end
+
+        private
+
+        def remove_empty_druid_path_parts(druid_path)
+          return unless File.directory?(druid_path) && Dir.empty?(druid_path)
+          return if druid_path == Settings.geohydra.stage # don't remove the stage directory
+
+          FileUtils.rm_rf(druid_path) # remove the emtpy directory
+          remove_empty_druid_path_parts(File.dirname(druid_path)) # remove parent directory if it's empty
+        end
+      end
+    end
+  end
+end

--- a/lib/robots/dor_repo/gis_delivery/metadata_cleanup.rb
+++ b/lib/robots/dor_repo/gis_delivery/metadata_cleanup.rb
@@ -14,8 +14,8 @@ module Robots
           logger.debug "metadata-cleanup working on #{bare_druid}"
           stage_dir = GisRobotSuite.locate_druid_path bare_druid, type: :stage
           content_dir = File.join(stage_dir, 'content')
-          FileUtils.rm_f Dir.glob("#{content_dir}/*") # remove all the files (not directories)
-          remove_empty_druid_path_parts(content_dir) if File.directory?(content_dir)
+          FileUtils.rm_r Dir.glob(content_dir) # Remove the content directory
+          remove_empty_druid_path_parts(File.dirname(content_dir))
         end
 
         private
@@ -24,8 +24,8 @@ module Robots
           return unless File.directory?(druid_path) && Dir.empty?(druid_path)
           return if druid_path == Settings.geohydra.stage # don't remove the stage directory
 
-          FileUtils.rm_rf(druid_path) # remove the emtpy directory
-          remove_empty_druid_path_parts(File.dirname(druid_path)) # remove parent directory if it's empty
+          FileUtils.rmdir(druid_path) # Safely remove the emtpy directory
+          remove_empty_druid_path_parts(File.dirname(druid_path)) # Check the parent directory
         end
       end
     end

--- a/spec/robots/dor_repo/gis_delivery/metadata_cleanup_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/metadata_cleanup_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Robots::DorRepo::GisDelivery::MetadataCleanup do
+  let(:workflow_client) { instance_double(Dor::Workflow::Client) }
+  let(:source_druid) { 'cv676dy5796' }
+  let(:source_dir) { File.join(DruidTools::Druid.new(source_druid, File.join(fixture_dir, 'stage')).path, 'content') }
+  let(:staging_dir) { DruidTools::Druid.new(druid, File.join(fixture_dir, 'stage')).path }
+
+  before do
+    FileUtils.mkdir_p(staging_dir)
+    FileUtils.cp_r(source_dir, staging_dir)
+    allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(workflow_client).to receive(:workflow_status).and_return('queued')
+    allow(workflow_client).to receive(:update_status)
+    allow(workflow_client).to receive(:update_error_status)
+    Robots::DorRepo::GisAssembly::ExtractIso19139Metadata.new.perform("druid:#{druid}")
+  end
+
+  context 'with ESRI metadata for a shapefile' do
+    let(:druid) { 'ab123cd4567' }
+    let(:esri_filename) { 'WATER_BODY.shp.xml' }
+
+    it 'generates an ISO 19139 XML document' do
+      expect(File.directory?(File.join(staging_dir, 'content'))).to be true
+      expect(File).to exist(File.join(staging_dir, 'content', 'WATER_BODY-iso19139.xml'))
+      described_class.new.perform("druid:#{druid}")
+      expect(File).not_to exist(File.join(staging_dir, 'content', 'WATER_BODY-iso19139.xml'))
+      expect(File.directory?(staging_dir)).to be false
+    end
+  end
+end

--- a/spec/robots/dor_repo/gis_delivery/metadata_cleanup_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/metadata_cleanup_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Robots::DorRepo::GisDelivery::MetadataCleanup do
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(workflow_client).to receive(:workflow_status).and_return('queued')
     allow(workflow_client).to receive(:update_status)
-    allow(workflow_client).to receive(:update_error_status)
-    Robots::DorRepo::GisAssembly::ExtractIso19139Metadata.new.perform("druid:#{druid}")
   end
 
   context 'with ESRI metadata for a shapefile' do
@@ -24,9 +22,9 @@ RSpec.describe Robots::DorRepo::GisDelivery::MetadataCleanup do
 
     it 'generates an ISO 19139 XML document' do
       expect(File.directory?(File.join(staging_dir, 'content'))).to be true
-      expect(File).to exist(File.join(staging_dir, 'content', 'WATER_BODY-iso19139.xml'))
+      expect(File).to exist(File.join(staging_dir, 'content', esri_filename))
       described_class.new.perform("druid:#{druid}")
-      expect(File).not_to exist(File.join(staging_dir, 'content', 'WATER_BODY-iso19139.xml'))
+      expect(File).not_to exist(File.join(staging_dir, 'content', esri_filename))
       expect(File.directory?(staging_dir)).to be false
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #840 

Cleans up the staging path for the druid by removing the `contents` data and recursively removing parent directories until a non-empty path is found.

## How was this change tested? 🤨

Unit test, verified locally that a close matching druid (i.e. `ab987th1234`) will not be removed when removing the druid tree for `ab123cd4567`.

Integration tests:
- https://argo-stage.stanford.edu/view/druid:mz464kc4897 (via preassembly)
- https://argo-stage.stanford.edu/view/druid:xn075jf4709 (non preassembly)

both show a successful `metadata-cleanup` step and I verified the druid paths are no longer on the staging directory.

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


