### PR TITLE
Make publication date required, but not publisher

### DIFF
--- a/spec/fixtures/bh432xr2264-iso19139.xml
+++ b/spec/fixtures/bh432xr2264-iso19139.xml
@@ -181,6 +181,16 @@
           <date>
             <CI_Date>
               <date>
+                <gco:Date>2008-06-14</gco:Date>
+              </date>
+              <dateType>
+                <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" codeSpace="ISOTC211/19115">creation</CI_DateTypeCode>
+              </dateType>
+            </CI_Date>
+          </date>
+          <date>
+            <CI_Date>
+              <date>
                 <gco:Date>2009-06-20</gco:Date>
               </date>
               <dateType>


### PR DESCRIPTION
## Why was this change made? 🤔
Adjust descriptive mapping to not require a publisher, and require a publication date. Also fix a bug where if there were multiple dates, the text of all of them concatenated was parsed. Instead, use the date with a type of "publication". 

## How was this change tested? 🤨
Unit and integration. 




