### PR TITLE
Ensure stats file is created

### DIFF
--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -79,6 +79,7 @@ module GisRobotSuite
 
     def compute_statistics
       Kernel.system("#{Settings.gdal_path}gdalinfo -mm -stats -norat -noct #{output_filepath}", exception: true)
+      raise "load-raster: #{bare_druid} gdalinfo did not create stats file" unless File.size?("#{output_filepath}.aux.xml")
     end
 
     def tmpdir


### PR DESCRIPTION
## Why was this change made? 🤔

Since load_raster expects to be able to rsync the statistics file that
is generated during the normalization step, we should have the
normalizer raise an error if it didn't get generated.

Refs #854

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


