### PR TITLE
No longer generate or copy `.aux.xml` statistics file.

### DIFF
--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -79,7 +79,6 @@ module GisRobotSuite
 
     def compute_statistics
       Kernel.system("#{Settings.gdal_path}gdalinfo -mm -stats -norat -noct #{output_filepath}", exception: true)
-      raise "load-raster: #{bare_druid} gdalinfo did not create stats file" unless File.size?("#{output_filepath}.aux.xml")
     end
 
     def tmpdir

--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -23,7 +23,6 @@ module GisRobotSuite
 
       epsg4326_projection? ? compress_only : reproject_and_compress
       convert_8bit_to_rgb if eight_bit?
-      compute_statistics
       tmpdir
     end
 
@@ -75,10 +74,6 @@ module GisRobotSuite
       Kernel.system("mv #{output_filepath} #{temp_filename}", exception: true)
       Kernel.system("#{Settings.gdal_path}gdal_translate -expand rgb #{temp_filename} #{output_filepath} -co 'COMPRESS=LZW'", exception: true)
       File.delete(temp_filename)
-    end
-
-    def compute_statistics
-      Kernel.system("#{Settings.gdal_path}gdalinfo -mm -stats -norat -noct #{output_filepath}", exception: true)
     end
 
     def tmpdir

--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -30,16 +30,6 @@ module Robots
             cmd = "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif"
             logger.debug "Running: #{cmd}"
             system(cmd, exception: true)
-
-            # copy statistics files (produced by RasterNormalizer#compute_statistics, as of March 2024)
-            stats_file = "#{tif_filename}.aux.xml"
-            if File.size?(stats_file)
-              cmd = "rsync -v '#{stats_file}' #{destination_path}/#{bare_druid}.tif.aux.xml"
-              logger.debug "Running: #{cmd}"
-              system(cmd, exception: true)
-            else
-              logger.debug "Skipping copy of #{stats_file} since it doesn't exist"
-            end
           end
         end
 

--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -32,9 +32,14 @@ module Robots
             system(cmd, exception: true)
 
             # copy statistics files (produced by RasterNormalizer#compute_statistics, as of March 2024)
-            cmd = "rsync -v '#{tif_filename}.aux.xml' #{destination_path}/#{bare_druid}.tif.aux.xml"
-            logger.debug "Running: #{cmd}"
-            system(cmd, exception: true)
+            stats_file = "#{tif_filename}.aux.xml"
+            if File.size?(stats_file)
+              cmd = "rsync -v '#{stats_file}' #{destination_path}/#{bare_druid}.tif.aux.xml"
+              logger.debug "Running: #{cmd}"
+              system(cmd, exception: true)
+            else
+              logger.debug "Skipping copy of #{stats_file} since it doesn't exist"
+            end
           end
         end
 

--- a/spec/gis_robot_suite/raster_normalizer_spec.rb
+++ b/spec/gis_robot_suite/raster_normalizer_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
       it 'normalizes the data' do
         expect(normalizer.normalize).to eq(tmpdir)
         expect(File).to exist(File.join(tmpdir, 'MCE_FI2G_2014.tif'))
-        expect(File).to exist(File.join(tmpdir, 'MCE_FI2G_2014.tif.aux.xml'))
 
         # Does not reproject
         expect(Kernel).not_to have_received(:system).with(
@@ -114,11 +113,6 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
         # Convert to RGB
         expect(Kernel).to have_received(:system).with(
           "gdal_translate -expand rgb /tmp/normalizeraster_bb021mm7809/raw8bit.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'",
-          exception: true
-        )
-        # Stats
-        expect(Kernel).to have_received(:system).with(
-          'gdalinfo -mm -stats -norat -noct /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif',
           exception: true
         )
       end
@@ -191,7 +185,6 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
       it 'normalizes the data' do
         expect(normalizer.normalize).to eq(tmpdir)
         expect(File).to exist(File.join(tmpdir, 'h_shade.tif'))
-        expect(File).to exist(File.join(tmpdir, 'h_shade.tif.aux.xml'))
 
         # Reprojects
         expect(Kernel).to have_received(:system).with(
@@ -206,11 +199,6 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
         # Not convert to RGB
         expect(Kernel).not_to have_received(:system).with(
           "gdal_translate -expand rgb /tmp/normalizeraster_vh469wk7989/raw8bit.tif /tmp/normalizeraster_vh469wk7989/h_shade.tif -co 'COMPRESS=LZW'",
-          exception: true
-        )
-        # Stats
-        expect(Kernel).to have_received(:system).with(
-          'gdalinfo -mm -stats -norat -noct /tmp/normalizeraster_vh469wk7989/h_shade.tif',
           exception: true
         )
       end

--- a/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_raster_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadRaster do
     it 'executes system commands to load raster' do
       test_perform(robot, druid)
       expect(robot).to have_received(:system).with(cmd_tif_sync, exception: true)
-      expect(robot).to have_received(:system).with(cmd_aux_sync, exception: true)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Experimentation suggests that the `.aux.xml` file is not actually needed by Geoserver and @kimdurante suggested that we no longer need to do this.

Fixes #854

## How was this change tested? 🤨

I ran a GIS item through Preassembly which gdalinfo doesn't create a .aux.xml file for. The accessioned data is in 002.zip in the Difficult Data folder: https://drive.google.com/drive/u/0/folders/1gY6_SgLWwJhtJrYsiAG5X5kgda741Lyo

@kimdurante also did some testing in stage

