### PR TITLE
Send filename when creating and updating styles

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 22
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 126
+  Max: 127
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs, MaxOptionalParameters.

--- a/lib/robots/dor_repo/gis_delivery/load_geoserver.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_geoserver.rb
@@ -232,8 +232,9 @@ module Robots
               logger.debug "load-geoserver: #{bare_druid} loaded style #{raster_style}"
               if style_exists.nil?
                 logger.debug "load-geoserver: #{bare_druid} saving new style #{raster_style}"
-                style.create(style_name: raster_style, filename: nil)
-                style.update(style_name: raster_style, filename: nil, payload: sldtxt)
+                filename = "#{raster_style}.sld"
+                style.create(style_name: raster_style, filename:)
+                style.update(style_name: raster_style, filename:, payload: sldtxt)
               end
             else
               raster_style = 'raster_grayband' # a simple band-oriented histogram adjusted style

--- a/spec/robots/dor_repo/gis_delivery/load_geoserver_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_geoserver_spec.rb
@@ -909,8 +909,8 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadGeoserver do
 
           it 'runs without error and updates style with correct payload' do
             test_perform(robot, druid)
-            expect(style).to have_received(:create).with(style_name: "raster_#{druid}", filename: nil)
-            expect(style).to have_received(:update).with(style_name: "raster_#{druid}", filename: nil, payload:)
+            expect(style).to have_received(:create).with(style_name: "raster_#{druid}", filename: "raster_#{druid}.sld")
+            expect(style).to have_received(:update).with(style_name: "raster_#{druid}", filename: "raster_#{druid}.sld", payload:)
           end
         end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Calling [Style.create](https://github.com/samvera-labs/geoserver-publish/blob/aec7c64311a17e2e948dd43b6523fdcc604d2837/lib/geoserver/publish/style.rb#L28-L32) without a filename causes Geoserver to throw a 500 error. This commit supplies a filename using the layer name + the ".sld" extension.

Fixes #860

## How was this change tested? 🤨

Running unit tests, and running the data through Preassembly in Stage and confirming it made it through accessioning. https://argo-stage.stanford.edu/view/druid:rz417vq6403



