### PR TITLE
Better system call error handling

### DIFF
--- a/lib/gis_robot_suite/arcgis_metadata_transformer.rb
+++ b/lib/gis_robot_suite/arcgis_metadata_transformer.rb
@@ -15,7 +15,7 @@ module GisRobotSuite
 
     def transform
       logger&.info("extracting metadata: generating #{output_file} using #{xslt_file}")
-      system("#{xslt_command} #{xslt_file} '#{esri_metadata_file}' | #{xml_lint_command} -o '#{output_file}' -", exception: true)
+      GisRobotSuite.run_system_command("#{xslt_command} #{xslt_file} '#{esri_metadata_file}' | #{xml_lint_command} -o '#{output_file}' -", logger:)
     end
 
     # Type of GIS data for this object

--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -40,7 +40,7 @@ module GisRobotSuite
 
       # reproject with gdalwarp (must uncompress here to prevent bloat)
       logger.info "load-raster: #{bare_druid} projecting #{geo_object_name} from #{projection_from_cocina_subject}"
-      Kernel.system("#{Settings.gdal_path}gdalwarp -r bilinear -t_srs EPSG:4326 #{input_filepath} #{temp_filepath} -co 'COMPRESS=NONE'", exception: true)
+      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdalwarp -r bilinear -t_srs EPSG:4326 #{input_filepath} #{temp_filepath} -co 'COMPRESS=NONE'", logger:)
       raise "load-raster: #{bare_druid} gdalwarp failed to create #{temp_filepath}" unless File.size?(temp_filepath)
 
       compress(temp_filepath, output_filepath)
@@ -53,7 +53,7 @@ module GisRobotSuite
 
     def compress(input_filepath, output_filepath)
       logger.info "load-raster: #{bare_druid} is compressing to #{projection_from_cocina_subject}"
-      Kernel.system("#{Settings.gdal_path}gdal_translate -a_srs EPSG:4326 #{input_filepath} #{output_filepath} -co 'COMPRESS=LZW'", exception: true)
+      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdal_translate -a_srs EPSG:4326 #{input_filepath} #{output_filepath} -co 'COMPRESS=LZW'", logger:)
       raise "load-raster: #{bare_druid} gdal_translate failed to create #{output_filepath}" unless File.size?(output_filepath)
     end
 
@@ -71,8 +71,8 @@ module GisRobotSuite
     def convert_8bit_to_rgb
       logger.info "load-raster: expanding color palette into rgb for #{output_filepath}"
       temp_filename = "#{tmpdir}/raw8bit.tif"
-      Kernel.system("mv #{output_filepath} #{temp_filename}", exception: true)
-      Kernel.system("#{Settings.gdal_path}gdal_translate -expand rgb #{temp_filename} #{output_filepath} -co 'COMPRESS=LZW'", exception: true)
+      GisRobotSuite.run_system_command("mv #{output_filepath} #{temp_filename}", logger:)
+      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdal_translate -expand rgb #{temp_filename} #{output_filepath} -co 'COMPRESS=LZW'", logger:)
       File.delete(temp_filename)
     end
 

--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -59,12 +59,12 @@ module GisRobotSuite
 
     def eight_bit?
       cmd = "#{Settings.gdal_path}gdalinfo -json -norat -noct '#{output_filepath}'"
-      IO.popen(cmd).read.tap do |gdalinfo_json_str|
-        gdalinfo_json = JSON.parse(gdalinfo_json_str)
-        bands = gdalinfo_json['bands']
-        # { "bands":[{ "band": 1, "block": [10503, 3], "type": "Byte", "colorInterpretation": "Palette" }] } # plus many other keys at each level
-        return true if bands.any? { |band| band.key?('block') && band['type'] == 'Byte' && band['colorInterpretation'] == 'Palette' }
-      end
+      gdalinfo_json_str = GisRobotSuite.run_system_command(cmd, logger:)[:stdout_str]
+      gdalinfo_json = JSON.parse(gdalinfo_json_str)
+      bands = gdalinfo_json['bands']
+      # { "bands":[{ "band": 1, "block": [10503, 3], "type": "Byte", "colorInterpretation": "Palette" }] } # plus many other keys at each level
+      return true if bands.any? { |band| band.key?('block') && band['type'] == 'Byte' && band['colorInterpretation'] == 'Palette' }
+
       false
     end
 

--- a/lib/gis_robot_suite/vector_normalizer.rb
+++ b/lib/gis_robot_suite/vector_normalizer.rb
@@ -49,7 +49,9 @@ module GisRobotSuite
       # See http://www.gdal.org/ogr2ogr.html
       output_filepath = File.join(tmpdir, "#{geo_object_name}.shp") # output shapefile
       logger.info "normalize-vector: #{bare_druid} is projecting #{geo_object_name} to EPSG:4326"
-      Kernel.system("env SHAPE_ENCODING= #{Settings.gdal_path}ogr2ogr -progress -t_srs '#{wkt}' '#{output_filepath}' '#{vector_filepath}'", exception: true) # prevent recoding
+
+      # prevent recoding
+      GisRobotSuite.run_system_command("env SHAPE_ENCODING= #{Settings.gdal_path}ogr2ogr -progress -t_srs '#{wkt}' '#{output_filepath}' '#{vector_filepath}'", logger:)
       raise "normalize-vector: #{bare_druid} failed to reproject #{vector_filepath}" unless File.size?(output_filepath)
     end
 

--- a/lib/robots/dor_repo/gis_assembly/generate_descriptive.rb
+++ b/lib/robots/dor_repo/gis_assembly/generate_descriptive.rb
@@ -13,7 +13,7 @@ module Robots
         def perform_work
           logger.debug "generate-descriptive working on #{bare_druid}"
 
-          description = GisRobotSuite::DescriptiveMetadataBuilder.build(cocina_model: cocina_object, bare_druid:, iso19139_ng:)
+          description = GisRobotSuite::DescriptiveMetadataBuilder.build(cocina_model: cocina_object, bare_druid:, iso19139_ng:, logger:)
           updated = cocina_object.new(description:)
           object_client.update(params: updated)
         end

--- a/lib/robots/dor_repo/gis_delivery/load_geoserver.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_geoserver.rb
@@ -187,7 +187,7 @@ module Robots
 
           # determine raster style
           begin
-            raster_style = "raster_#{GisRobotSuite.determine_raster_style("#{Settings.geohydra.geotiff.dir}/#{bare_druid}.tif")}"
+            raster_style = "raster_#{GisRobotSuite.determine_raster_style("#{Settings.geohydra.geotiff.dir}/#{bare_druid}.tif", logger:)}"
           rescue StandardError => e
             logger.info "Raster style determination failed: #{e.inspect}. Using default `raster`"
             raster_style = 'raster'

--- a/lib/robots/dor_repo/gis_delivery/load_raster.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_raster.rb
@@ -29,7 +29,7 @@ module Robots
                                end
             cmd = "rsync -v '#{tif_filename}' #{destination_path}/#{bare_druid}.tif"
             logger.debug "Running: #{cmd}"
-            system(cmd, exception: true)
+            GisRobotSuite.run_system_command(cmd, logger:)
           end
         end
 

--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -25,18 +25,17 @@ module Robots
             # sniff out shapefile from extraction
             shp_filename = Dir.glob("#{tmpdir}/*.shp").first
             sql_filename = shp_filename.gsub(/\.shp$/, '.sql')
-            stderr_filename = "#{tmpdir}/shp2pgsql.err"
 
             logger.debug "load-vector: #{bare_druid} is working on Shapefile: #{shp_filename}"
 
             # first try decoding with UTF-8 and if that fails use LATIN1
             # see also https://github.com/sul-dlss/gis-robot-suite/issues/850
             begin
-              run_shp2pgsql('4326', 'UTF-8', shp_filename, schema, sql_filename, stderr_filename)
+              run_shp2pgsql('4326', 'UTF-8', shp_filename, schema, sql_filename)
             rescue RuntimeError => e
               logger.warn("#{druid} -- fell through to LATIN1 encoding after calling run_shp2pgsql with " \
                           "UTF-8 encoding and encountering error: #{e.message}; #{e.backtrace.join('; ')}")
-              run_shp2pgsql('4326', 'LATIN1', shp_filename, schema, sql_filename, stderr_filename)
+              run_shp2pgsql('4326', 'LATIN1', shp_filename, schema, sql_filename)
             end
 
             # Load the data into PostGIS
@@ -57,13 +56,10 @@ module Robots
           @rootdir ||= GisRobotSuite.locate_druid_path bare_druid, type: :stage
         end
 
-        def run_shp2pgsql(projection, encoding, shp_filename, schema, sql_filename, stderr_filename)
+        def run_shp2pgsql(projection, encoding, shp_filename, schema, sql_filename)
           # TODO: Perhaps put the .sql data into the content directory as .zip for derivative
           # NOTE: -G for the geography column causes some issues with GeoServer
-          cmd = "shp2pgsql -s #{projection} -d -D -I -W #{encoding} " \
-                "'#{shp_filename}' #{schema}.#{bare_druid} " \
-                "> '#{sql_filename}' 2> '#{stderr_filename}'"
-          logger.debug "Running: #{cmd}"
+          cmd = "shp2pgsql -s #{projection} -d -D -I -W #{encoding} '#{shp_filename}' #{schema}.#{bare_druid} > '#{sql_filename}'"
           GisRobotSuite.run_system_command(cmd, logger:)
           raise "normalize-vector: #{bare_druid} shp2pgsql generated no SQL?" unless File.size?(sql_filename)
         end

--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -43,7 +43,7 @@ module Robots
             cmd = 'psql --no-psqlrc --no-password --quiet ' \
                   "--file='#{sql_filename}' "
             logger.debug "Running: #{cmd}"
-            system(cmd, exception: true)
+            GisRobotSuite.run_system_command(cmd, logger:)
           end
         end
 
@@ -64,7 +64,7 @@ module Robots
                 "'#{shp_filename}' #{schema}.#{bare_druid} " \
                 "> '#{sql_filename}' 2> '#{stderr_filename}'"
           logger.debug "Running: #{cmd}"
-          system(cmd, exception: true)
+          GisRobotSuite.run_system_command(cmd, logger:)
           raise "normalize-vector: #{bare_druid} shp2pgsql generated no SQL?" unless File.size?(sql_filename)
         end
       end

--- a/spec/gis_robot_suite/descriptive_metadata_builder_spec.rb
+++ b/spec/gis_robot_suite/descriptive_metadata_builder_spec.rb
@@ -8,24 +8,25 @@ RSpec.describe GisRobotSuite::DescriptiveMetadataBuilder do
   let(:staging_dir) { File.join(fixture_dir, 'stage', bare_druid, 'temp') }
   let(:iso19139_xml_file) { Dir.glob("#{fixture_dir}/#{bare_druid}-iso19139.xml").first }
   let(:iso19139_ng) { Nokogiri::XML(File.read(iso19139_xml_file)) }
+  let(:logger) { instance_double(Logger, info: nil, debug: nil) }
 
   describe '.dd2ddmmss_abs' do
     it 'converts DD to DDMMSS' do
-      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:dd2ddmmss_abs, -109.758319)).to eq('109°45ʹ30ʺ')
-      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:dd2ddmmss_abs, 48.999336)).to eq('48°59ʹ58ʺ')
+      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:dd2ddmmss_abs, -109.758319)).to eq('109°45ʹ30ʺ')
+      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:dd2ddmmss_abs, 48.999336)).to eq('48°59ʹ58ʺ')
     end
   end
 
   describe '.to_coordinates_ddmmss' do
     it 'converts MARC to DDMMSS' do
-      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:to_coordinates_ddmmss, [-180, 180, 90, -90])).to eq('W 180°--E 180°/N 90°--S 90°')
-      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:to_coordinates_ddmmss,
-                                                                                [-109.758319, -88.990844, 48.999336,
-                                                                                 29.423028])).to eq('W 109°45ʹ30ʺ--W 88°59ʹ27ʺ/N 48°59ʹ58ʺ--N 29°25ʹ23ʺ')
+      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:to_coordinates_ddmmss, [-180, 180, 90, -90])).to eq('W 180°--E 180°/N 90°--S 90°')
+      expect(described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:to_coordinates_ddmmss,
+                                                                                         [-109.758319, -88.990844,
+                                                                                          48.999336, 29.423028])).to eq('W 109°45ʹ30ʺ--W 88°59ʹ27ʺ/N 48°59ʹ58ʺ--N 29°25ʹ23ʺ')
     end
 
     it 'handles bad arguments' do
-      expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:to_coordinates_ddmmss, [-185, 185, 95, -95]) }.to raise_error(ArgumentError)
+      expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:to_coordinates_ddmmss, [-185, 185, 95, -95]) }.to raise_error(ArgumentError)
     end
   end
 
@@ -34,38 +35,40 @@ RSpec.describe GisRobotSuite::DescriptiveMetadataBuilder do
 
     describe '.title' do
       it 'raises when title missing' do
-        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:title) }.to raise_error(RuntimeError, "Title is missing for #{bare_druid}.")
+        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:title) }.to raise_error(RuntimeError, "Title is missing for #{bare_druid}.")
       end
     end
 
     describe '.event' do
       it 'raises when publication is missing' do
-        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:event) }.to raise_error(RuntimeError, "Publication date is missing for #{bare_druid}.")
+        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:event) }.to raise_error(RuntimeError, "Publication date is missing for #{bare_druid}.")
       end
     end
 
     describe '.admin_identifier' do
       it 'raises when admin identifier is missing' do
-        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:admin_identifier) }
+        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:admin_identifier) }
           .to raise_error(RuntimeError, "identifier not found in '//gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString'")
       end
     end
 
     describe '.map_projection' do
       it 'raises when map projection data is missing' do
-        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:map_projection) }.to raise_error(RuntimeError, "Map projection is missing for #{bare_druid}.")
+        expect do
+          described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:map_projection)
+        end.to raise_error(RuntimeError, "Map projection is missing for #{bare_druid}.")
       end
     end
 
     describe '.language' do
       it 'raises when language is missing' do
-        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:language) }.to raise_error(RuntimeError, "Language missing for #{bare_druid}.")
+        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:language) }.to raise_error(RuntimeError, "Language missing for #{bare_druid}.")
       end
     end
 
     describe '.abstract_note' do
       it 'raises when abstract is missing' do
-        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:).send(:abstract_note) }.to raise_error(RuntimeError, "Abstract missing for #{bare_druid}.")
+        expect { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:).send(:abstract_note) }.to raise_error(RuntimeError, "Abstract missing for #{bare_druid}.")
       end
     end
   end

--- a/spec/gis_robot_suite/raster_normalizer_spec.rb
+++ b/spec/gis_robot_suite/raster_normalizer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
 
   before do
     FileUtils.mkdir_p(tmpdir)
-    allow(Kernel).to receive(:system).and_call_original
+    allow(GisRobotSuite).to receive(:run_system_command).and_call_original
   end
 
   after do
@@ -101,19 +101,19 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
         expect(File).to exist(File.join(tmpdir, 'MCE_FI2G_2014.tif'))
 
         # Does not reproject
-        expect(Kernel).not_to have_received(:system).with(
+        expect(GisRobotSuite).not_to have_received(:run_system_command).with(
           "gdalwarp -r bilinear -t_srs EPSG:4326 spec/fixtures/workspace/bb/021/mm/7809/bb021mm7809/content/MCE_FI2G_2014.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014_uncompressed.tif -co 'COMPRESS=NONE'", # rubocop:disable Layout/LineLength
-          exception: true
+          logger:
         )
         # Compress
-        expect(Kernel).to have_received(:system).with(
+        expect(GisRobotSuite).to have_received(:run_system_command).with(
           "gdal_translate -a_srs EPSG:4326 spec/fixtures/workspace/bb/021/mm/7809/bb021mm7809/content/MCE_FI2G_2014.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'", # rubocop:disable Layout/LineLength
-          exception: true
+          logger:
         )
         # Convert to RGB
-        expect(Kernel).to have_received(:system).with(
+        expect(GisRobotSuite).to have_received(:run_system_command).with(
           "gdal_translate -expand rgb /tmp/normalizeraster_bb021mm7809/raw8bit.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'",
-          exception: true
+          logger:
         )
       end
     end
@@ -187,19 +187,19 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
         expect(File).to exist(File.join(tmpdir, 'h_shade.tif'))
 
         # Reprojects
-        expect(Kernel).to have_received(:system).with(
+        expect(GisRobotSuite).to have_received(:run_system_command).with(
           "gdalwarp -r bilinear -t_srs EPSG:4326 spec/fixtures/workspace/vh/469/wk/7989/vh469wk7989/content/h_shade /tmp/normalizeraster_vh469wk7989/h_shade_uncompressed.tif -co 'COMPRESS=NONE'", # rubocop:disable Layout/LineLength
-          exception: true
+          logger:
         )
         # Compress
-        expect(Kernel).to have_received(:system).with(
+        expect(GisRobotSuite).to have_received(:run_system_command).with(
           "gdal_translate -a_srs EPSG:4326 /tmp/normalizeraster_vh469wk7989/h_shade_uncompressed.tif /tmp/normalizeraster_vh469wk7989/h_shade.tif -co 'COMPRESS=LZW'",
-          exception: true
+          logger:
         )
         # Not convert to RGB
-        expect(Kernel).not_to have_received(:system).with(
+        expect(GisRobotSuite).not_to have_received(:run_system_command).with(
           "gdal_translate -expand rgb /tmp/normalizeraster_vh469wk7989/raw8bit.tif /tmp/normalizeraster_vh469wk7989/h_shade.tif -co 'COMPRESS=LZW'",
-          exception: true
+          logger:
         )
       end
     end

--- a/spec/gis_robot_suite/vector_normalizer_spec.rb
+++ b/spec/gis_robot_suite/vector_normalizer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe GisRobotSuite::VectorNormalizer do
     FileUtils.mkdir_p(tmpdir)
     stub_request(:get, 'https://spatialreference.org/ref/epsg/4326/prettywkt/')
       .to_return(status: 200, body: wkt, headers: {})
-    allow(Kernel).to receive(:system).and_call_original
+    allow(GisRobotSuite).to receive(:run_system_command).and_call_original
   end
 
   after do
@@ -37,9 +37,9 @@ RSpec.describe GisRobotSuite::VectorNormalizer do
       expect(File).to exist(File.join(tmpdir, 'sanluisobispo1996.dbf'))
       expect(File).to exist(File.join(tmpdir, 'sanluisobispo1996.shx'))
 
-      expect(Kernel).to have_received(:system).with(
+      expect(GisRobotSuite).to have_received(:run_system_command).with(
         "env SHAPE_ENCODING= ogr2ogr -progress -t_srs 'GEOGCS[\"WGS 84\", DATUM[\"WGS_1984\", SPHEROID[\"WGS 84\",6378137,298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], AUTHORITY[\"EPSG\",\"6326\"]], PRIMEM[\"Greenwich\",0, AUTHORITY[\"EPSG\",\"8901\"]], UNIT[\"degree\",0.0174532925199433, AUTHORITY[\"EPSG\",\"9122\"]], AUTHORITY[\"EPSG\",\"4326\"]]' '/tmp/normalizevector_cc044gt0726/sanluisobispo1996.shp' 'spec/fixtures/workspace/cc/044/gt/0726/cc044gt0726/content/sanluisobispo1996.shp'", # rubocop:disable Layout/LineLength
-        exception: true
+        logger:
       )
     end
   end

--- a/spec/gis_robot_suite_spec.rb
+++ b/spec/gis_robot_suite_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe GisRobotSuite do
   describe '.determine_raster_style' do
     let(:rgb8_file) { File.join(fixture_dir, 'tif_files/MCE_AF2G_2010.tif') }
     let(:grayscale8_file) { File.join(fixture_dir, 'stage/bh/432/xr/2264/bh432xr2264/content/51002.tif') }
+    let(:logger) { instance_double(Logger, info: nil, debug: nil) }
 
     after do
       # the *.aux.xml files are written by gdalinfo when it computes image statistics (will be regenerated if not present)
@@ -130,8 +131,8 @@ RSpec.describe GisRobotSuite do
     end
 
     it 'determines the correct raster style' do
-      expect(described_class.determine_raster_style(rgb8_file)).to eq('rgb8')
-      expect(described_class.determine_raster_style(grayscale8_file)).to eq('grayscale8')
+      expect(described_class.determine_raster_style(rgb8_file, logger:)).to eq('rgb8')
+      expect(described_class.determine_raster_style(grayscale8_file, logger:)).to eq('grayscale8')
     end
   end
 

--- a/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    allow(IO).to receive(:popen).and_call_original
+    allow(GisRobotSuite).to receive(:run_system_command).and_call_original
     stub_request(:get, 'https://spatialreference.org/ref/epsg/4326/prettywkt/')
       .to_return(status: 200, body: wkt, headers: {})
   end
@@ -164,7 +164,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
       it 'updates the cocina with the bounding box' do
         test_perform(robot, druid)
         expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
-        expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/normalizeraster_nj441df9572/MCE_AF2G_2010.tif'")
+        expect(GisRobotSuite).to have_received(:run_system_command).with("gdalinfo -json '/tmp/normalizeraster_nj441df9572/MCE_AF2G_2010.tif'", logger: robot.logger)
       end
     end
 
@@ -292,7 +292,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
       it 'updates the cocina with the bounding box' do
         test_perform(robot, druid)
         expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
-        expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/normalizeraster_nj441df9572/MCE_AF2G_2010.tif'")
+        expect(GisRobotSuite).to have_received(:run_system_command).with("gdalinfo -json '/tmp/normalizeraster_nj441df9572/MCE_AF2G_2010.tif'", logger: robot.logger)
       end
     end
 
@@ -450,7 +450,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
       it 'updates the cocina with the new bounding box' do
         test_perform(robot, druid)
         expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
-        expect(IO).to have_received(:popen).with("gdalinfo -json '/tmp/normalizeraster_nj441df9572/MCE_AF2G_2010.tif'")
+        expect(GisRobotSuite).to have_received(:run_system_command).with("gdalinfo -json '/tmp/normalizeraster_nj441df9572/MCE_AF2G_2010.tif'", logger: robot.logger)
       end
     end
   end
@@ -695,15 +695,14 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
     end
 
     def ci?
-      IO.popen("#{Settings.gdal_path}ogr2ogr --version") do |f|
-        return f.read.include?('GDAL 3.4')
-      end
+      cmd_result = GisRobotSuite.run_system_command("#{Settings.gdal_path}ogr2ogr --version", logger: Logger.new($stdout)) # provide a throw away logger
+      cmd_result[:stdout_str].include?('GDAL 3.4')
     end
 
     it 'updates the cocina with the bounding box' do
       test_perform(robot, druid)
       expect(object_client).to have_received(:update) { |args| expect(args[:params].description.to_h).to match Cocina::Models::Description.new(expected_description).to_h }
-      expect(IO).to have_received(:popen).with("ogrinfo -ro -so -al '/tmp/normalizevector_cc044gt0726/sanluisobispo1996.shp'")
+      expect(GisRobotSuite).to have_received(:run_system_command).with("ogrinfo -ro -so -al '/tmp/normalizevector_cc044gt0726/sanluisobispo1996.shp'", logger: robot.logger)
     end
   end
 end

--- a/spec/robots/dor_repo/gis_assembly/generate_descriptive_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/generate_descriptive_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Robots::DorRepo::GisAssembly::GenerateDescriptive do
       allow(Settings.geohydra).to receive(:stage).and_return('spec/fixtures/stage')
       allow(Settings.purl).to receive(:url).and_return('https://purl.stanford.edu')
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      # allow(IO).to receive(:popen).and_return(nil)
     end
 
     after { cleanup }

--- a/spec/robots/dor_repo/gis_delivery/load_geoserver_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_geoserver_spec.rb
@@ -864,7 +864,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadGeoserver do
         let(:layer) { instance_double(Geoserver::Publish::Layer) }
 
         before do
-          allow(GisRobotSuite).to receive(:determine_raster_style).and_return(style_name)
+          allow(GisRobotSuite).to receive(:determine_raster_style).with('/geotiff/dg548ft1892.tif', logger: a_kind_of(Logger)).and_return(style_name)
           allow(Geoserver::Publish::Coverage).to receive(:new).and_return(coverage)
           allow(Geoserver::Publish::CoverageStore).to receive(:new).and_return(coverage_store)
           allow(Geoserver::Publish::Style).to receive(:new).and_return(style)

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   let(:normalizer_tmpdir) { "/tmp/normalizevector_#{bare_druid}" }
   let(:shp_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.shp" }
   let(:sql_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.sql" }
-  let(:stderr_filename) { "#{normalizer_tmpdir}/shp2pgsql.err" }
   let(:robot) { described_class.new }
   let(:logger) { robot.logger }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
@@ -109,7 +108,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
     let(:media_type) { 'application/x-esri-shapefile' }
     let(:rootdir) { GisRobotSuite.locate_druid_path bare_druid, type: :workspace }
     let(:cmd_psql) { "psql --no-psqlrc --no-password --quiet --file='#{sql_filename}' " }
-    let(:cmd_shp2pgsql) { "shp2pgsql -s 4326 -d -D -I -W UTF-8 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
+    let(:cmd_shp2pgsql) { "shp2pgsql -s 4326 -d -D -I -W UTF-8 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}'" }
     let(:wkt) do
       'GEOGCS["WGS 84", DATUM["WGS_1984", SPHEROID["WGS 84",6378137,298.257223563, AUTHORITY["EPSG","7030"]], AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich",0, AUTHORITY["EPSG","8901"]], UNIT["degree",0.0174532925199433, AUTHORITY["EPSG","9122"]], AUTHORITY["EPSG","4326"]]' # rubocop:disable Layout/LineLength
     end
@@ -135,7 +134,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
 
     context 'when decoding UTF-8 fails' do
       let(:decoding_err_msg) { 'Could not decode UTF-8 for some reason 🤷' }
-      let(:cmd_shp2pgsql_retry) { "shp2pgsql -s 4326 -d -D -I -W LATIN1 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
+      let(:cmd_shp2pgsql_retry) { "shp2pgsql -s 4326 -d -D -I -W LATIN1 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}'" }
 
       before do
         allow(robot.logger).to receive(:warn)

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   let(:sql_filename) { "#{normalizer_tmpdir}/sanluisobispo1996.sql" }
   let(:stderr_filename) { "#{normalizer_tmpdir}/shp2pgsql.err" }
   let(:robot) { described_class.new }
+  let(:logger) { robot.logger }
   let(:workflow_client) { instance_double(Dor::Workflow::Client) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_object) }
   let(:cocina_object) { build(:dro, id: druid).new(description:) }
@@ -83,28 +84,30 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
   end
 
   before do
-    allow(robot).to receive(:system)
+    allow(GisRobotSuite).to receive(:run_system_command).and_call_original
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    allow(GisRobotSuite::VectorNormalizer).to receive(:new).and_return(normalizer)
   end
 
   context 'when the object is not a vector' do
     let(:media_type) { 'image/tiff' }
-    let(:normalizer) { instance_double(GisRobotSuite::VectorNormalizer, with_normalized: true) }
+
+    before do
+      allow(GisRobotSuite::VectorNormalizer).to receive(:new)
+      allow(logger).to receive(:info)
+    end
 
     it 'does nothing' do
       test_perform(robot, druid)
-      expect(normalizer).not_to have_received(:with_normalized)
-      expect(robot).not_to have_received(:system)
+      expect(logger).to have_received(:info).with("load-vector: #{bare_druid} is not a vector, skipping")
+      expect(GisRobotSuite::VectorNormalizer).not_to have_received(:new)
+      expect(GisRobotSuite).not_to have_received(:run_system_command)
     end
   end
 
   context 'when the object is a vector' do
     let(:media_type) { 'application/x-esri-shapefile' }
-    let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil) }
     let(:rootdir) { GisRobotSuite.locate_druid_path bare_druid, type: :workspace }
-    let(:normalizer) { GisRobotSuite::VectorNormalizer.new(logger:, bare_druid:, rootdir:) }
     let(:cmd_psql) { "psql --no-psqlrc --no-password --quiet --file='#{sql_filename}' " }
     let(:cmd_shp2pgsql) { "shp2pgsql -s 4326 -d -D -I -W UTF-8 '#{shp_filename}' druid.#{bare_druid} > '#{sql_filename}' 2> '#{stderr_filename}'" }
     let(:wkt) do
@@ -114,17 +117,20 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
     before do
       stub_request(:get, 'https://spatialreference.org/ref/epsg/4326/prettywkt/')
         .to_return(status: 200, body: wkt, headers: {})
-      allow(robot).to receive(:normalizer).and_return(normalizer)
-      allow(normalizer).to receive_messages(cleanup: true)
+      allow(robot).to receive(:logger).and_return(logger)
+      allow(GisRobotSuite).to receive(:run_system_command).with(cmd_shp2pgsql, logger:)
+      allow(GisRobotSuite).to receive(:run_system_command).with(cmd_psql, logger:)
       allow(File).to receive(:size?).and_call_original
       allow(File).to receive(:size?).with(sql_filename).and_return('123')
     end
 
     it 'executes system commands to load vector' do
       test_perform(robot, druid)
-      expect(normalizer).to have_received(:cleanup)
-      expect(robot).to have_received(:system).with(cmd_shp2pgsql, exception: true)
-      expect(robot).to have_received(:system).with(cmd_psql, exception: true)
+      actual_tmpdir = robot.send(:normalizer).send(:tmpdir)
+      expect(File.exist?(actual_tmpdir)).to be false # LoadVector#normalizer.with_normalized should call cleanup, which should get rid of the temp dir
+      expect(actual_tmpdir).to eq(normalizer_tmpdir) # confirm that the expected temp dir path we're using for other comparisons is accurate
+      expect(GisRobotSuite).to have_received(:run_system_command).with(cmd_shp2pgsql, logger:)
+      expect(GisRobotSuite).to have_received(:run_system_command).with(cmd_psql, logger:)
     end
 
     context 'when decoding UTF-8 fails' do
@@ -133,20 +139,21 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
 
       before do
         allow(robot.logger).to receive(:warn)
-        allow(robot).to receive(:system) do |cmd|
+        allow(GisRobotSuite).to receive(:run_system_command).with(cmd_shp2pgsql, logger:) do |cmd|
           raise decoding_err_msg if cmd.include?('-W UTF-8')
         end
+        allow(GisRobotSuite).to receive(:run_system_command).with(cmd_shp2pgsql_retry, logger:)
       end
 
       it 'logs a warning and re-tries shp2pgsql with LATIN1 encoding' do
         expect { test_perform(robot, druid) }.not_to raise_error
 
-        expect(robot).to have_received(:system).with(cmd_shp2pgsql, exception: true)
+        expect(GisRobotSuite).to have_received(:run_system_command).with(cmd_shp2pgsql, logger:)
 
         base_err_msg = 'fell through to LATIN1 encoding after calling run_shp2pgsql with UTF-8 encoding and encountering error'
         backtrace_regex = "#{__FILE__}:\\d+.*in .block.*; "
         expect(robot.logger).to have_received(:warn).with(/#{druid} -- #{base_err_msg}: #{decoding_err_msg}; .*#{backtrace_regex}/)
-        expect(robot).to have_received(:system).with(cmd_shp2pgsql_retry, exception: true)
+        expect(GisRobotSuite).to have_received(:run_system_command).with(cmd_shp2pgsql_retry, logger:)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #820

This PR gets rid of all of the uses i could find of `Kernel.system`, `Object#system` (i.e. just `system` from within whatever class), and `IO.popen` that I could find.  I didn't see any commands executed by wrapping a string in backticks, other than one very idiomatic (for us at least) `git` call in `config/deploy.rb`.

The PR switches them out for a new method, `GisRobotSuite.run_system_command`, which makes the error handling and error message surfacing more consistent and robust, imho.  This should hopefully make it easier to figure out why a workflow step fails when it hits an error executing a command (esp when the failure is transient, specific to the input data, or encountered on a temp file).

## How was this change tested? 🤨

- [x] CI
- [x] integration tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


