### PR TITLE
Remove unused stanford-mods dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools'
 gem 'geoserver-publish', '>= 0.5.0' # samvera labs
 gem 'lyber-core', '~> 7.1'
-gem 'stanford-mods' # for GisDelivery::LoadGeoserver
 
 gem 'config'
 gem 'fastimage', '~> 2.2' # to get mimetype in GenerateStructural

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
-    iso-639 (0.3.6)
     json (2.7.1)
     jsonpath (1.1.5)
       multi_json
@@ -164,11 +163,6 @@ GEM
     mini_exiftool (2.10.4)
     mini_portile2 (2.8.5)
     minitest (5.22.3)
-    mods (3.0.4)
-      edtf (~> 3.0)
-      iso-639
-      nokogiri (>= 1.6.6)
-      nom-xml (~> 1.0)
     multi_json (1.15.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
@@ -183,9 +177,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
-    nom-xml (1.2.0)
-      i18n
-      nokogiri
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
     openapi_parser (1.0.0)
@@ -273,9 +264,6 @@ GEM
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (3.3.9)
-      activesupport
-      mods (~> 3.0, >= 3.0.4)
     stringio (3.1.0)
     super_diff (0.11.0)
       attr_extras (>= 6.2.4)
@@ -325,7 +313,6 @@ DEPENDENCIES
   sidekiq-pro!
   simplecov
   slop
-  stanford-mods
   webmock
   zeitwerk (~> 2.1)
 


### PR DESCRIPTION
## Why was this change made? 🤔

We don't need this.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


