### PR TITLE
Change start-accessioning-workflow so it closes the object version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Kim Durante &amp; Darren Hardy (2015) Discovery, Management, and Preservation of
 * `reset-geowebcache` :: Reset GeoWebCache for the layer
 * `finish-gis-delivery-workflow` :: Connect to public and restricted GeoServers to verify layer
 * `metadata-cleanup` :: Remove the staging druid tree for the working druid
-* `start-accession-workflow` :: Start accessionWF
+* `start-accession-workflow` :: Closes the object version to initiate the accessioning workflow
 
 Data Wrangling
 ==============

--- a/lib/robots/dor_repo/gis_delivery/start_accession_workflow.rb
+++ b/lib/robots/dor_repo/gis_delivery/start_accession_workflow.rb
@@ -10,8 +10,7 @@ module Robots
 
         def perform_work
           logger.debug "start-accession-workflow working on #{bare_druid}"
-          current_version = object_client.version.current
-          workflow_service.create_workflow_by_name(druid, 'accessionWF', version: current_version)
+          object_client.version.close
         end
       end
     end

--- a/spec/robots/dor_repo/gis_delivery/start_accession_workflow_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/start_accession_workflow_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Robots::DorRepo::GisDelivery::StartAccessionWorkflow do
+  let(:robot) { described_class.new }
+  let(:druid) { 'fx392st8577' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+  let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, close: nil) }
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(robot.logger).to receive(:debug)
+  end
+
+  describe '#perform_work' do
+    it 'logs a debug message' do
+      test_perform(robot, druid)
+      expect(robot.logger).to have_received(:debug).once.with("start-accession-workflow working on #{druid}").once
+    end
+
+    it 'uses dor-services-client to close the object version' do
+      test_perform(robot, druid)
+      expect(version_client).to have_received(:close).once
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made?

Fixes #873

This initiates the accessioning workflow and makes sure accessioning does not receive an open object version.

# How was this change tested?

CI
