### PR TITLE
Ensure system commands quote filenames

### DIFF
--- a/lib/gis_robot_suite/raster_normalizer.rb
+++ b/lib/gis_robot_suite/raster_normalizer.rb
@@ -40,7 +40,7 @@ module GisRobotSuite
 
       # reproject with gdalwarp (must uncompress here to prevent bloat)
       logger.info "load-raster: #{bare_druid} projecting #{geo_object_name} from #{projection_from_cocina_subject}"
-      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdalwarp -r bilinear -t_srs EPSG:4326 #{input_filepath} #{temp_filepath} -co 'COMPRESS=NONE'", logger:)
+      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdalwarp -r bilinear -t_srs EPSG:4326 '#{input_filepath}' '#{temp_filepath}' -co 'COMPRESS=NONE'", logger:)
       raise "load-raster: #{bare_druid} gdalwarp failed to create #{temp_filepath}" unless File.size?(temp_filepath)
 
       compress(temp_filepath, output_filepath)
@@ -53,7 +53,7 @@ module GisRobotSuite
 
     def compress(input_filepath, output_filepath)
       logger.info "load-raster: #{bare_druid} is compressing to #{projection_from_cocina_subject}"
-      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdal_translate -a_srs EPSG:4326 #{input_filepath} #{output_filepath} -co 'COMPRESS=LZW'", logger:)
+      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdal_translate -a_srs EPSG:4326 '#{input_filepath}' '#{output_filepath}' -co 'COMPRESS=LZW'", logger:)
       raise "load-raster: #{bare_druid} gdal_translate failed to create #{output_filepath}" unless File.size?(output_filepath)
     end
 
@@ -71,8 +71,8 @@ module GisRobotSuite
     def convert_8bit_to_rgb
       logger.info "load-raster: expanding color palette into rgb for #{output_filepath}"
       temp_filename = "#{tmpdir}/raw8bit.tif"
-      GisRobotSuite.run_system_command("mv #{output_filepath} #{temp_filename}", logger:)
-      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdal_translate -expand rgb #{temp_filename} #{output_filepath} -co 'COMPRESS=LZW'", logger:)
+      GisRobotSuite.run_system_command("mv '#{output_filepath}' '#{temp_filename}'", logger:)
+      GisRobotSuite.run_system_command("#{Settings.gdal_path}gdal_translate -expand rgb '#{temp_filename}' '#{output_filepath}' -co 'COMPRESS=LZW'", logger:)
       File.delete(temp_filename)
     end
 

--- a/spec/gis_robot_suite/raster_normalizer_spec.rb
+++ b/spec/gis_robot_suite/raster_normalizer_spec.rb
@@ -102,17 +102,17 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
 
         # Does not reproject
         expect(GisRobotSuite).not_to have_received(:run_system_command).with(
-          "gdalwarp -r bilinear -t_srs EPSG:4326 spec/fixtures/workspace/bb/021/mm/7809/bb021mm7809/content/MCE_FI2G_2014.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014_uncompressed.tif -co 'COMPRESS=NONE'", # rubocop:disable Layout/LineLength
+          "gdalwarp -r bilinear -t_srs EPSG:4326 'spec/fixtures/workspace/bb/021/mm/7809/bb021mm7809/content/MCE_FI2G_2014.tif' '/tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014_uncompressed.tif' -co 'COMPRESS=NONE'", # rubocop:disable Layout/LineLength
           logger:
         )
         # Compress
         expect(GisRobotSuite).to have_received(:run_system_command).with(
-          "gdal_translate -a_srs EPSG:4326 spec/fixtures/workspace/bb/021/mm/7809/bb021mm7809/content/MCE_FI2G_2014.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'", # rubocop:disable Layout/LineLength
+          "gdal_translate -a_srs EPSG:4326 'spec/fixtures/workspace/bb/021/mm/7809/bb021mm7809/content/MCE_FI2G_2014.tif' '/tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif' -co 'COMPRESS=LZW'", # rubocop:disable Layout/LineLength
           logger:
         )
         # Convert to RGB
         expect(GisRobotSuite).to have_received(:run_system_command).with(
-          "gdal_translate -expand rgb /tmp/normalizeraster_bb021mm7809/raw8bit.tif /tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif -co 'COMPRESS=LZW'",
+          "gdal_translate -expand rgb '/tmp/normalizeraster_bb021mm7809/raw8bit.tif' '/tmp/normalizeraster_bb021mm7809/MCE_FI2G_2014.tif' -co 'COMPRESS=LZW'",
           logger:
         )
       end
@@ -188,17 +188,17 @@ RSpec.describe GisRobotSuite::RasterNormalizer do
 
         # Reprojects
         expect(GisRobotSuite).to have_received(:run_system_command).with(
-          "gdalwarp -r bilinear -t_srs EPSG:4326 spec/fixtures/workspace/vh/469/wk/7989/vh469wk7989/content/h_shade /tmp/normalizeraster_vh469wk7989/h_shade_uncompressed.tif -co 'COMPRESS=NONE'", # rubocop:disable Layout/LineLength
+          "gdalwarp -r bilinear -t_srs EPSG:4326 'spec/fixtures/workspace/vh/469/wk/7989/vh469wk7989/content/h_shade' '/tmp/normalizeraster_vh469wk7989/h_shade_uncompressed.tif' -co 'COMPRESS=NONE'", # rubocop:disable Layout/LineLength
           logger:
         )
         # Compress
         expect(GisRobotSuite).to have_received(:run_system_command).with(
-          "gdal_translate -a_srs EPSG:4326 /tmp/normalizeraster_vh469wk7989/h_shade_uncompressed.tif /tmp/normalizeraster_vh469wk7989/h_shade.tif -co 'COMPRESS=LZW'",
+          "gdal_translate -a_srs EPSG:4326 '/tmp/normalizeraster_vh469wk7989/h_shade_uncompressed.tif' '/tmp/normalizeraster_vh469wk7989/h_shade.tif' -co 'COMPRESS=LZW'",
           logger:
         )
         # Not convert to RGB
         expect(GisRobotSuite).not_to have_received(:run_system_command).with(
-          "gdal_translate -expand rgb /tmp/normalizeraster_vh469wk7989/raw8bit.tif /tmp/normalizeraster_vh469wk7989/h_shade.tif -co 'COMPRESS=LZW'",
+          "gdal_translate -expand rgb '/tmp/normalizeraster_vh469wk7989/raw8bit.tif' '/tmp/normalizeraster_vh469wk7989/h_shade.tif' -co 'COMPRESS=LZW'",
           logger:
         )
       end


### PR DESCRIPTION
## Why was this change made? 🤔

If a filename has spaces in it, a system command that includes it as an
argument is likely to fail unless it is quoted. This is done pretty much
everywhere else in gis-robot-suite, but there were a few edge cases.

Fixes #878

## How was this change tested? 🤨

* unit tests
* integration tests

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


