### PR TITLE
load-vector needs to catch the correct exception

### DIFF
--- a/lib/robots/dor_repo/gis_delivery/load_vector.rb
+++ b/lib/robots/dor_repo/gis_delivery/load_vector.rb
@@ -32,7 +32,7 @@ module Robots
             # see also https://github.com/sul-dlss/gis-robot-suite/issues/850
             begin
               run_shp2pgsql('4326', 'UTF-8', shp_filename, schema, sql_filename)
-            rescue RuntimeError => e
+            rescue GisRobotSuite::SystemCommandExecutionError => e
               logger.warn("#{druid} -- fell through to LATIN1 encoding after calling run_shp2pgsql with " \
                           "UTF-8 encoding and encountering error: #{e.message}; #{e.backtrace.join('; ')}")
               run_shp2pgsql('4326', 'LATIN1', shp_filename, schema, sql_filename)

--- a/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
+++ b/spec/robots/dor_repo/gis_delivery/load_vector_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Robots::DorRepo::GisDelivery::LoadVector do
       before do
         allow(robot.logger).to receive(:warn)
         allow(GisRobotSuite).to receive(:run_system_command).with(cmd_shp2pgsql, logger:) do |cmd|
-          raise decoding_err_msg if cmd.include?('-W UTF-8')
+          raise GisRobotSuite::SystemCommandExecutionError, decoding_err_msg if cmd.include?('-W UTF-8')
         end
         allow(GisRobotSuite).to receive(:run_system_command).with(cmd_shp2pgsql_retry, logger:)
       end


### PR DESCRIPTION
## Why was this change made? 🤔

We need to retry loading with LATIN1 when the initial load as UTF-8 fails. When we changed the exception handling around GisRobotSuite::run_system_command the type of exception that was thrown also got changed which meant the fallback to load as LATIN1 failed to execute.

Fixes #883

## How was this change tested? 🤨

Unit tests.


