### PR TITLE
Raise an error when starting workflow on an object that is not open

### DIFF
--- a/lib/robots/dor_repo/gis_assembly/start_gis_assembly_workflow.rb
+++ b/lib/robots/dor_repo/gis_assembly/start_gis_assembly_workflow.rb
@@ -10,7 +10,7 @@ module Robots
         end
 
         def perform_work
-          Honeybadger.notify('[WARNING] GIS assembly has been started with an object that is not open') unless object_client.version.status.open?
+          raise 'GIS assembly has been started with an object that is not open' unless object_client.version.status.open?
         end
       end
     end

--- a/spec/robots/dor_repo/gis_assembly/start_gis_assembly_workflow_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/start_gis_assembly_workflow_spec.rb
@@ -20,19 +20,15 @@ RSpec.describe Robots::DorRepo::GisAssembly::StartGisAssemblyWorkflow do
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
-    before { allow(Honeybadger).to receive(:notify) }
-
-    it 'does not notify Honeybadger' do
-      perform
-      expect(Honeybadger).not_to have_received(:notify)
+    it 'does not raise an error' do
+      expect { perform }.not_to raise_error
     end
 
     context 'when object is not open' do
       let(:version_open) { false }
 
-      it 'notifies Honeybadger' do
-        perform
-        expect(Honeybadger).to have_received(:notify).once.with('[WARNING] GIS assembly has been started with an object that is not open')
+      it 'raises an error' do
+        expect { perform }.to raise_error 'GIS assembly has been started with an object that is not open'
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #893


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


