### PR TITLE
Update ruby orb to 4.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.2.0
+  ruby-rails: sul-dlss/ruby-rails@4.2.1
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔

Latest version of orb is 4.2.1

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


