### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'geoserver-publish', '>= 0.5.0' # samvera labs
 gem 'lyber-core', '~> 7.1'
 
 gem 'config'
+gem 'csv'
 gem 'fastimage', '~> 2.2' # to get mimetype in GenerateStructural
 gem 'honeybadger'
 gem 'pry' # for console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    csv (3.2.8)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -300,6 +301,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-shared_configs
   config
+  csv
   debug
   dlss-capistrano
   dor-services-client (~> 14.0)


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.

# How was this change tested?

CI
