### PR TITLE
Ruby 3.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.2.3
+  ruby-rails: sul-dlss/ruby-rails@4.3.0
 workflows:
   build:
     jobs:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -334,3 +334,50 @@ RSpecRails/NegationBeValid: # new in 2.23
   Enabled: true
 RSpecRails/TravelAround: # new in 2.19
   Enabled: true
+
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Lint/ArrayLiteralInRegexp: # new in 1.71
+  Enabled: true
+Lint/ConstantReassignment: # new in 1.70
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
+  Enabled: true
+Lint/SharedMutableDefault: # new in 1.70
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/DigChain: # new in 1.69
+  Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
+Style/FileTouch: # new in 1.69
+  Enabled: true
+Style/HashSlice: # new in 1.71
+  Enabled: true
+Style/ItAssignment: # new in 1.70
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
   - rubocop-rspec_rails
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   DisplayCopNames: true
   SuggestExtensions: false
   Exclude:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ These robots require several dependencies needed to perform the GIS workflow ste
  - `xsltproc` and `xmllint` for transforming XML files
  - rsync also used as part of the robot process and is needed
 
+## System Commands
+There are many ways to execute commands on the host OS in Ruby.  For calling the aforementioned tools (GDAL commands, `xsltproc`, etc), it's suggested to first reach for `GisRobotSuite.run_system_command`, since that is consistent with the rest of the codebase, and includes some helpful logging and error handling.
+
 # Documentation
 
 GIS data has its own set of names, standards and conventions that can be difficult for newcomers. To better understand some of these please see the [Geo4LibCamp Glossary](https://geo4libcamp.org/glossary/) as well as the following article which describes the initial goals for supporting GIS in SDR:

--- a/lib/gis_robot_suite/gazetteer.rb
+++ b/lib/gis_robot_suite/gazetteer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 # Gazetteer data look like this:
 #   "l_kw","geonames_kw","geonames_id","lc_kw","lc_id"
 #   "Ahmadābād District (India)","Ahmadābād",1279234,"Ahmadābād (India : District)","n78019943"


### PR DESCRIPTION
## Why was this change made? 🤔

patch party to upgrade all deployed environments to ruby 3.4.1

## How was this change tested? 🤨

integration tests on stage and QA (gis_accessioning_spec, preassembly_gis_raster_accessioning_spec, preassembly_gis_vector_accessioning_spec)

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


