### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,7 +2,5 @@
 
 server 'kurma-robots-prod-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,7 +2,5 @@
 
 server 'kurma-robots-qa-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,7 +2,5 @@
 
 server 'kurma-robots-stage-01.stanford.edu', user: 'lyberadmin', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'staging'
 set :default_env, robot_environment: fetch(:deploy_environment)


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.