### PR TITLE
Remove linked directory for arcgis configs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :deploy_to, '/opt/app/lyberadmin/gis-robot-suite'
 set :linked_files, %w[config/honeybadger.yml]
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w[log run tmp/pids config/certs config/settings config/ArcGIS]
+set :linked_dirs, %w[log run tmp/pids config/certs config/settings]
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION


## Why was this change made? 🤔

This stopped being in shared configs after https://github.com/sul-dlss/gis-robot-suite/commit/83011281a1e8efafff2edbd6b025eb5d97cf40e6

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that GIS accessioning works properly in [stage|qa] environment, in addition to specs. ⚡


