### PR TITLE
Ensure we compile the python gdal against the installed version

### DIFF
--- a/lib/gis_robot_suite/validate_cloud_optimized_geotiff.py
+++ b/lib/gis_robot_suite/validate_cloud_optimized_geotiff.py
@@ -15,7 +15,7 @@
 
 # /// script
 # dependencies = [
-#   "gdal",
+#   "gdal==3.11.4",
 # ]
 # ///
 


### PR DESCRIPTION


## Why was this change made? 🤔
Currently ubuntu installs 3.11.4.  If you don't specify this it tries to build with 3.12.4 and gets this error message: 
```
Python bindings of GDAL 3.12.4 require at least libgdal 3.12.4, but 3.11.4 was found
```


## How was this change tested? 🤨
integration test
