### PR TITLE
Remove rubocop-capybara

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
 plugins:
-  - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec
   - rubocop-rspec_rails
@@ -12,10 +11,10 @@ AllCops:
   SuggestExtensions: false
   Exclude:
     - Gemfile.lock
-    - '**/*.md'
-    - 'bin/console'
-    - 'config/boot.rb'
-    - 'vendor/**/*' # avoid running rubocop on cached bundler
+    - "**/*.md"
+    - "bin/console"
+    - "config/boot.rb"
+    - "vendor/**/*" # avoid running rubocop on cached bundler
 
 Metrics/BlockLength:
   Exclude:
@@ -230,24 +229,6 @@ Style/SwapValues: # new in 1.1
   Enabled: true
 Style/YAMLFileRead: # new in 1.53
   Enabled: true
-Capybara/ClickLinkOrButtonStyle: # new in 2.19
-  Enabled: true
-Capybara/RSpec/MatchStyle: # new in 2.17
-  Enabled: true
-Capybara/RSpec/NegationMatcher: # new in 2.14
-  Enabled: true
-Capybara/RedundantWithinFind: # new in 2.20
-  Enabled: true
-Capybara/SpecificActions: # new in 2.14
-  Enabled: true
-Capybara/SpecificFinders: # new in 2.13
-  Enabled: true
-Capybara/RSpec/SpecificMatcher: # new in 2.12
-  Enabled: true
-Capybara/RSpec/HaveSelector: # new in 2.19
-  Enabled: true
-Capybara/RSpec/PredicateMatcher: # new in 2.19
-  Enabled: true
 FactoryBot/AssociationStyle: # new in 2.23
   Enabled: true
 FactoryBot/ConsistentParenthesesStyle: # new in 2.14
@@ -407,10 +388,6 @@ Style/ItBlockParameter: # new in 1.75
 Style/RedundantArrayFlatten: # new in 1.76
   Enabled: true
 Style/RedundantFormat: # new in 1.72
-  Enabled: true
-Capybara/FindAllFirst: # new in 2.22
-  Enabled: true
-Capybara/RSpec/NegationMatcherAfterVisit: # new in 2.22
   Enabled: true
 RSpec/IncludeExamples: # new in 3.6
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ end
 group :development do
   gem 'rspec'
   gem 'rubocop', require: false
-  gem 'rubocop-capybara'
   gem 'rubocop-factory_bot'
   gem 'rubocop-rspec'
   gem 'rubocop-rspec_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,9 +256,6 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.23.0)
-      lint_roller (~> 1.1)
-      rubocop (~> 1.81)
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -341,7 +338,6 @@ DEPENDENCIES
   rspec
   rspec_junit_formatter
   rubocop
-  rubocop-capybara
   rubocop-factory_bot
   rubocop-rspec
   rubocop-rspec_rails


### PR DESCRIPTION


## Why was this change made? 🤔
We don't have capybara, so there is no need to lint it.


## How was this change tested? 🤨
ci

