### PR TITLE
Add --force option to tippecanoe, to permit re-generating

### DIFF
--- a/lib/gis_robot_suite/vector_derivative_generator.rb
+++ b/lib/gis_robot_suite/vector_derivative_generator.rb
@@ -31,7 +31,8 @@ module GisRobotSuite
       FileUtils.rm_f(temp_fgb_output)
 
       # Generate PMTiles from FlatGeoBuf
-      pmtiles_command = "tippecanoe -o #{Shellwords.escape(pmtiles_path.to_s)} -zg #{Shellwords.escape(fgb_path.to_s)} --drop-densest-as-needed --extend-zooms-if-still-dropping"
+      pmtiles_command = "tippecanoe -o #{Shellwords.escape(pmtiles_path.to_s)} -zg #{Shellwords.escape(fgb_path.to_s)} " \
+                        '--drop-densest-as-needed --extend-zooms-if-still-dropping --force'
       GisRobotSuite.run_system_command(pmtiles_command, logger: logger)
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Avoids this issue on re-run.
```
tippecanoe: Tileset \"/dor/workspace/qd/988/ty/2410/qd988ty2410/content/AirMonitoringStations.pmtiles\" already exists. You can use --force if you want to delete the old tileset
```

## How was this change tested? 🤨
ci

