### PR TITLE
Add Cocina file presentation data for jp2 preview

### DIFF
--- a/lib/gis_robot_suite/raster_preview_generator.rb
+++ b/lib/gis_robot_suite/raster_preview_generator.rb
@@ -16,7 +16,7 @@ module GisRobotSuite
     end
 
     def generate
-      command = "gdal convert #{Shellwords.escape(input_path.to_s)} #{Shellwords.escape(output_path.to_s)}"
+      command = "gdal convert --overwrite #{Shellwords.escape(input_path.to_s)} #{Shellwords.escape(output_path.to_s)}"
       GisRobotSuite.run_system_command(command, logger: logger)
     end
 

--- a/lib/gis_robot_suite/structural_updator.rb
+++ b/lib/gis_robot_suite/structural_updator.rb
@@ -11,8 +11,8 @@ module GisRobotSuite
     delegate :version, to: :cocina_object
 
     # @return [Cocina::Models::DRO] the updated DRO with the new file added to the structural contains
-    def add_file(filename:, use:, file_set:, mimetype: nil, preserve: true)
-      @cocina_object = cocina_object.new(structural: structural_with_file(filename:, mimetype:, use:, preserve:, file_set:))
+    def add_file(filename:, use:, file_set:, mimetype: nil, preserve: true, presentation: nil)
+      @cocina_object = cocina_object.new(structural: structural_with_file(filename:, mimetype:, use:, preserve:, file_set:, presentation:))
     end
 
     # @return [Cocina::Models::DRO] the updated DRO with the matching files removed from the structural contains
@@ -22,9 +22,13 @@ module GisRobotSuite
 
     private
 
-    def structural_with_file(filename:, mimetype:, use:, file_set:, preserve: true)
+    def structural_with_file(filename:, mimetype:, use:, file_set:, preserve: true, presentation: nil)
       objectfile = Assembly::ObjectFile.new(filename)
-      file_params = GisRobotSuite::FileParamBuilder.build(objectfile:, file_access:, version:, mimetype:, use:, preserve:)
+      file_params = if presentation
+                      GisRobotSuite::ImageFileParamBuilder.build(objectfile:, file_access:, version:, mimetype:, use:, preserve:, presentation:)
+                    else
+                      GisRobotSuite::FileParamBuilder.build(objectfile:, file_access:, version:, mimetype:, use:, preserve:)
+                    end
       file = Cocina::Models::File.new(file_params)
 
       current_fs = find_file_set(file_set)

--- a/lib/gis_robot_suite/vector_preview_generator.rb
+++ b/lib/gis_robot_suite/vector_preview_generator.rb
@@ -26,7 +26,7 @@ module GisRobotSuite
         GisRobotSuite.run_system_command(rasterize_command, logger: logger)
 
         # Convert temporary TIFF to JP2
-        convert_command = "gdal convert #{Shellwords.escape(temp_tif_path.to_s)} #{Shellwords.escape(output_path.to_s)}"
+        convert_command = "gdal convert --overwrite #{Shellwords.escape(temp_tif_path.to_s)} #{Shellwords.escape(output_path.to_s)}"
         GisRobotSuite.run_system_command(convert_command, logger: logger)
       ensure
         # Make sure we clean up the temporary TIFF file

--- a/lib/robots/dor_repo/gis_derivative/create_derivatives.rb
+++ b/lib/robots/dor_repo/gis_derivative/create_derivatives.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'shellwords'
+
 module Robots
   module DorRepo
     module GisDerivative
@@ -57,7 +60,8 @@ module Robots
           updater.add_file(filename: workspace_path(cog_filename), use: 'derivative', preserve: false, file_set:, mimetype: COG_MIME_TYPE)
 
           jp2_filename = create_preview_jp2(cocina_file.filename, GisRobotSuite::RasterPreviewGenerator)
-          updater.add_file(filename: workspace_path(jp2_filename), use: 'thumbnail', preserve: false, file_set:, mimetype: JP2_MIME_TYPE)
+          updater.add_file(filename: workspace_path(jp2_filename), use: 'thumbnail', preserve: false, file_set:, mimetype: JP2_MIME_TYPE,
+                           presentation: jp2_presentation(workspace_path(jp2_filename)))
         end
 
         def create_vector_derivatives(cocina_file, file_set)
@@ -71,8 +75,8 @@ module Robots
           updater.add_file(filename: workspace_path(pmtiles_filename), use: 'derivative', preserve: false, file_set:, mimetype: PMTILES_MIME_TYPE)
 
           jp2_filename = create_preview_jp2(cocina_file.filename, GisRobotSuite::VectorPreviewGenerator)
-
-          updater.add_file(filename: workspace_path(jp2_filename), use: 'thumbnail', preserve: false, file_set:, mimetype: JP2_MIME_TYPE)
+          updater.add_file(filename: workspace_path(jp2_filename), use: 'thumbnail', preserve: false, file_set:, mimetype: JP2_MIME_TYPE,
+                           presentation: jp2_presentation(workspace_path(jp2_filename)))
         end
 
         def raster?(cocina_file)
@@ -115,6 +119,12 @@ module Robots
           GisRobotSuite::VectorDerivativeGenerator.generate(input_path: input, fgb_path: fgb_output, pmtiles_path: pmtiles_output, logger: logger)
 
           [fgb_filename, pmtiles_filename]
+        end
+
+        def jp2_presentation(path)
+          result = GisRobotSuite.run_system_command("gdalinfo -json #{Shellwords.escape(path.to_s)}", logger: logger)
+          width, height = JSON.parse(result[:stdout_str])['size']
+          { height:, width: }
         end
 
         def workspace_path(filename)

--- a/spec/gis_robot_suite/raster_preview_generator_spec.rb
+++ b/spec/gis_robot_suite/raster_preview_generator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GisRobotSuite::RasterPreviewGenerator do
       described_class.generate(input_path: input_path, output_path: output_path, logger: logger)
 
       expect(GisRobotSuite).to have_received(:run_system_command).with(
-        "gdal convert #{Shellwords.escape(input_path)} #{Shellwords.escape(output_path)}",
+        "gdal convert --overwrite #{Shellwords.escape(input_path)} #{Shellwords.escape(output_path)}",
         logger: logger
       )
     end

--- a/spec/gis_robot_suite/vector_preview_generator_spec.rb
+++ b/spec/gis_robot_suite/vector_preview_generator_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GisRobotSuite::VectorPreviewGenerator do
       )
 
       expect(GisRobotSuite).to have_received(:run_system_command).with(
-        "gdal convert #{Shellwords.escape(temp_tif_path.to_s)} #{Shellwords.escape(output_path.to_s)}",
+        "gdal convert --overwrite #{Shellwords.escape(temp_tif_path.to_s)} #{Shellwords.escape(output_path.to_s)}",
         logger: logger
       )
 

--- a/spec/robots/dor_repo/gis_derivative/create_derivatives_spec.rb
+++ b/spec/robots/dor_repo/gis_derivative/create_derivatives_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(GisRobotSuite).to receive(:locate_druid_path).and_return(workspace_path.parent)
     allow(GisRobotSuite).to receive(:run_system_command)
+    allow(GisRobotSuite).to receive(:run_system_command).with(/gdalinfo -json/, any_args)
+                                                        .and_return({ stdout_str: '{"size": [1024, 768]}' })
     workspace_path.mkpath
     File.write(master_file_path, 'fake content')
     # This exists because we're stubbing out the call to `gdal raster convert'
@@ -74,7 +76,10 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
       new_contains = params.structural.contains.first.structural.contains
       expect(new_contains.count).to eq 3
       expect(new_contains.map(&:use)).to eq %w[master derivative thumbnail]
-      expect(new_contains.find { |f| f.use == 'thumbnail' }.hasMimeType).to eq 'image/jp2'
+      jp2_file = new_contains.find { |f| f.use == 'thumbnail' }
+      expect(jp2_file.hasMimeType).to eq 'image/jp2'
+      expect(jp2_file.presentation.height).to eq 768
+      expect(jp2_file.presentation.width).to eq 1024
     end
   end
 
@@ -125,6 +130,9 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
         expect(new_contains.count).to eq 4
         expect(new_contains.map(&:use)).to eq %w[master derivative derivative thumbnail]
         expect(new_contains.map(&:hasMimeType)).to contain_exactly('application/vnd.shp', 'application/vnd.fgb', 'application/vnd.pmtiles', 'image/jp2')
+        jp2_file = new_contains.find { |f| f.use == 'thumbnail' }
+        expect(jp2_file.presentation.height).to eq 768
+        expect(jp2_file.presentation.width).to eq 1024
       end
     end
 


### PR DESCRIPTION
and permit overwrites

## Why was this change made? 🤔

Purl requires jp2 to have presentation data.


## How was this change tested? 🤨
tested on stage

