### PR TITLE
Handle deriving projection names without IDs

### DIFF
--- a/lib/gis_robot_suite/descriptive_metadata_builder.rb
+++ b/lib/gis_robot_suite/descriptive_metadata_builder.rb
@@ -164,12 +164,14 @@ module GisRobotSuite
 
       if system.empty? || code.empty?
         file = vector_filepath || raster_filepath
-        system, code = projection_from_gdal(file) if file
+        projection = projection_from_gdal(file) if file
+      else
+        projection = "#{system}::#{code}" # Uses '::' since the spec requires a version here (e.g., :7.4:) but it's generally left blank
       end
 
-      raise "Map projection is missing for #{bare_druid}." if system.blank? || code.blank?
+      raise "Map projection is missing for #{bare_druid}." if projection.blank?
 
-      { value: "#{system}::#{code}", type: 'map projection' } # Uses '::' since the spec requires a version here (e.g., :7.4:) but it's generally left blank
+      { value: projection, type: 'map projection' }
     end
 
     def projection_from_gdal(file)
@@ -181,17 +183,24 @@ module GisRobotSuite
                 json.dig('layers', 0, 'geometryFields', 0, 'coordinateSystem', 'projjson', 'id') ||
                 json.dig('coordinateSystem', 'projjson', 'id')
 
-      if id_node && id_node['authority'] && id_node['code']
-        [id_node['authority'], id_node['code'].to_s]
-      else
-        wkt = json.dig('coordinateSystem', 'wkt') ||
-              json.dig('layers', 0, 'geometryFields', 0, 'coordinateSystem', 'wkt')
+      system, code = if id_node && id_node['authority'] && id_node['code']
+                       [id_node['authority'], id_node['code'].to_s]
+                     else
+                       wkt = json.dig('coordinateSystem', 'wkt') ||
+                             json.dig('layers', 0, 'geometryFields', 0, 'coordinateSystem', 'wkt')
 
-        if wkt && (m = wkt.match(/ID\["([^"]+)",\s*(\d+)\]\s*\]\s*\z/m))
-          [m[1], m[2]]
-        else
-          [nil, nil]
-        end
+                       if wkt && (m = wkt.match(/ID\["([^"]+)",\s*(\d+)\]\s*\]\s*\z/m))
+                         [m[1], m[2]]
+                       end
+                     end
+
+      if system.present? && code.present?
+        "#{system}::#{code}"
+      else
+        # Some projections don't have an authority or code, but do have a name
+        json.dig('stac', 'proj:projjson', 'name') ||
+          json.dig('layers', 0, 'geometryFields', 0, 'coordinateSystem', 'projjson', 'name') ||
+          json.dig('coordinateSystem', 'projjson', 'name')
       end
     rescue StandardError => e
       logger.error("Failed to obtain projection info using gdal info for #{bare_druid}: #{e.message}")

--- a/spec/gis_robot_suite/descriptive_metadata_builder_spec.rb
+++ b/spec/gis_robot_suite/descriptive_metadata_builder_spec.rb
@@ -103,6 +103,21 @@ RSpec.describe GisRobotSuite::DescriptiveMetadataBuilder do
           expect(builder.send(:map_projection)).to eq({ value: 'EPSG::4326', type: 'map projection' })
         end
       end
+
+      context 'when the projection has a name but no ID' do
+        let(:builder) { described_class.new(cocina_model:, bare_druid:, iso19139_ng:, logger:) }
+
+        before do
+          allow(builder).to receive_messages(vector_filepath: '/path/to/vector.shp', raster_filepath: nil)
+          allow(GisRobotSuite).to receive(:run_system_command).with(/gdal info .* -f json/, any_args).and_return(
+            { stdout_str: '{"coordinateSystem":{"wkt":"PROJCRS[\"California Albers\"]","projjson":{"name":"California Albers"}}}' }
+          )
+        end
+
+        it 'uses the name instead' do
+          expect(builder.send(:map_projection)).to eq({ value: 'California Albers', type: 'map projection' })
+        end
+      end
     end
 
     describe '.language' do


### PR DESCRIPTION
Some objects have projections like "California Albers" that don't
have an assigned authority or ID in the metadata returned from
gdal's info command.

Ref #1129
