### PR TITLE
Temporarily pin lyber-core to < 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ gem 'assembly-objectfile'
 gem 'cocina-models'
 gem 'dor-services-client'
 gem 'druid-tools'
-gem 'lyber-core'
+# Temporarily pinned lyber-core on 7/10/2026 since >v9.0 lybercore has version-aware breaking changes requiring updates
+# to all consumers simultaneously. See https://github.com/sul-dlss/dor-services-app/pull/6196
+gem 'lyber-core', '~> 8.0' # For robots
 gem 'preservation-client'
 
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    lyber-core (8.1.0)
+    lyber-core (8.2.0)
       activesupport
       config
       dor-services-client
@@ -336,7 +336,7 @@ DEPENDENCIES
   dor-services-client
   druid-tools
   honeybadger
-  lyber-core
+  lyber-core (~> 8.0)
   preservation-client
   rake
   rspec


### PR DESCRIPTION
## Why was this change made? 🤔

To prevent breaking change in lyber-core being deployed until ready.