### PR TITLE
Skip metadata transformation if xml file isn't present

### DIFF
--- a/lib/gis_robot_suite/arcgis_metadata_transformer.rb
+++ b/lib/gis_robot_suite/arcgis_metadata_transformer.rb
@@ -19,6 +19,13 @@ module GisRobotSuite
       output_file
     end
 
+    def metadata?
+      esri_metadata_file
+      true
+    rescue RuntimeError
+      false
+    end
+
     # Type of GIS data for this object
     def data_type
       file_name = File.basename(esri_metadata_file)
@@ -49,9 +56,6 @@ module GisRobotSuite
     # XML metadata file exported from ArcGIS
     def esri_metadata_file
       GisRobotSuite.locate_esri_metadata(File.join(staging_dir, 'content'))
-    rescue RuntimeError => e
-      logger&.error "extract-#{output}-metadata: #{bare_druid} is missing ESRI metadata file"
-      raise e
     end
 
     # Filename of the original GIS metadata without any extensions

--- a/lib/robots/dor_repo/gis_assembly/extract_fgdc_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_fgdc_metadata.rb
@@ -11,7 +11,16 @@ module Robots
         def perform_work
           logger.debug "extract-fgdc working on #{bare_druid}"
 
-          GisRobotSuite::ArcgisMetadataTransformer.transform(bare_druid, 'ArcGIS2FGDC.xsl', 'fgdc.xml', logger:)
+          arcgis_transformer = GisRobotSuite::ArcgisMetadataTransformer.new(bare_druid, 'ArcGIS2FGDC.xsl', 'fgdc.xml', logger)
+          return missing_metadata_return_state unless arcgis_transformer.metadata?
+
+          arcgis_transformer.transform
+        end
+
+        private
+
+        def missing_metadata_return_state
+          LyberCore::ReturnState.new(status: :skipped, note: "#{bare_druid} has no ESRI metadata file in staging")
         end
       end
     end

--- a/lib/robots/dor_repo/gis_assembly/extract_iso19110_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_iso19110_metadata.rb
@@ -12,6 +12,7 @@ module Robots
           logger.debug "extract-iso19110 working on #{bare_druid}"
 
           arcgis_transformer = GisRobotSuite::ArcgisMetadataTransformer.new(bare_druid, 'arcgis_to_iso19110.xsl', 'iso19110.xml', logger)
+          return missing_metadata_return_state unless arcgis_transformer.metadata?
           return unless generate_for_datatype?(arcgis_transformer.data_type)
 
           output_file = arcgis_transformer.transform
@@ -19,6 +20,10 @@ module Robots
         end
 
         private
+
+        def missing_metadata_return_state
+          LyberCore::ReturnState.new(status: :skipped, note: "#{bare_druid} has no ESRI metadata file in staging")
+        end
 
         def updated_cocina_with(output_file)
           updater = GisRobotSuite::StructuralUpdator.new(cocina_object)

--- a/lib/robots/dor_repo/gis_assembly/extract_iso19139_metadata.rb
+++ b/lib/robots/dor_repo/gis_assembly/extract_iso19139_metadata.rb
@@ -11,11 +11,18 @@ module Robots
         def perform_work
           logger.debug "extract-iso19139 working on #{bare_druid}"
 
-          output_file = GisRobotSuite::ArcgisMetadataTransformer.transform(bare_druid, 'ArcGIS2ISO19139.xsl', 'iso19139.xml', logger:)
+          arcgis_transformer = GisRobotSuite::ArcgisMetadataTransformer.new(bare_druid, 'ArcGIS2ISO19139.xsl', 'iso19139.xml', logger)
+          return missing_metadata_return_state unless arcgis_transformer.metadata?
+
+          output_file = arcgis_transformer.transform
           object_client.update(params: updated_cocina_with(output_file))
         end
 
         private
+
+        def missing_metadata_return_state
+          LyberCore::ReturnState.new(status: :skipped, note: "#{bare_druid} has no ESRI metadata file in staging")
+        end
 
         def updated_cocina_with(output_file)
           updater = GisRobotSuite::StructuralUpdator.new(cocina_object)

--- a/spec/robots/dor_repo/gis_assembly/extract_fgdc_metadata_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_fgdc_metadata_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::GisAssembly::ExtractFgdcMetadata do
+  subject(:perform) { test_perform(robot, druid) }
+
   let(:robot) { described_class.new }
 
   let(:process_response) { instance_double(Dor::Services::Response::Process, status: 'queued') }
@@ -21,7 +23,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractFgdcMetadata do
     cleanup
     allow(Dor::Services::Client).to receive(:object).with("druid:#{druid}").and_return(object_client)
     allow(workflow_client).to receive(:process).with('extract-fgdc-metadata').and_return(process_client)
-    test_perform(robot, druid)
+    perform
   end
 
   after { cleanup }
@@ -50,6 +52,16 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractFgdcMetadata do
 
     it 'generates an FGDC XML document' do
       expect(File).to exist(File.join(staging_dir, 'CLOWNS_OF_AMERICA-fgdc.xml'))
+    end
+  end
+
+  context 'without ESRI metadata' do
+    let(:druid) { 'bb045mm1234' }
+
+    it 'skips the step' do
+      expect(perform).to be_a(LyberCore::ReturnState)
+      expect(perform.status).to eq 'skipped'
+      expect(perform.note).to eq 'bb045mm1234 has no ESRI metadata file in staging'
     end
   end
 end

--- a/spec/robots/dor_repo/gis_assembly/extract_iso19110_metadata_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_iso19110_metadata_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19110Metadata do
+  subject(:perform) { test_perform(robot, druid) }
+
   let(:robot) { described_class.new }
 
   let(:process_response) { instance_double(Dor::Services::Response::Process, status: 'queued') }
@@ -63,7 +65,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19110Metadata do
     cleanup
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(workflow_client).to receive(:process).with('extract-iso19110-metadata').and_return(process_client)
-    test_perform(robot, druid)
+    perform
   end
 
   after { cleanup }
@@ -96,6 +98,18 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19110Metadata do
 
     it 'generates an ISO 19110 XML document' do
       expect(File).to exist(File.join(staging_dir, 'CLOWNS_OF_AMERICA-iso19110.xml'))
+    end
+  end
+
+  context 'without ESRI metadata' do
+    let(:druid) { 'druid:bb045mm1234' }
+    let(:esri_filename) { 'somefile.txt' }
+
+    it 'skips the step without updating the object' do
+      expect(perform).to be_a(LyberCore::ReturnState)
+      expect(perform.status).to eq 'skipped'
+      expect(perform.note).to eq 'bb045mm1234 has no ESRI metadata file in staging'
+      expect(object_client).not_to have_received(:update)
     end
   end
 end

--- a/spec/robots/dor_repo/gis_assembly/extract_iso19139_metadata_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_iso19139_metadata_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19139Metadata do
+  subject(:perform) { test_perform(robot, druid) }
+
   let(:robot) { described_class.new }
 
   let(:process_response) { instance_double(Dor::Services::Response::Process, status: 'queued') }
@@ -63,7 +65,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19139Metadata do
     cleanup
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(workflow_client).to receive(:process).with('extract-iso19139-metadata').and_return(process_client)
-    test_perform(robot, druid)
+    perform
   end
 
   after { cleanup }
@@ -104,6 +106,18 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractIso19139Metadata do
         file = args[:params].structural.contains.first.structural.contains.last
         expect(file.filename).to eq 'CLOWNS_OF_AMERICA-iso19139.xml'
       end
+    end
+  end
+
+  context 'without ESRI metadata' do
+    let(:druid) { 'druid:bb045mm1234' }
+    let(:esri_filename) { 'somefile.txt' }
+
+    it 'skips the step without updating the object' do
+      expect(perform).to be_a(LyberCore::ReturnState)
+      expect(perform.status).to eq 'skipped'
+      expect(perform.note).to eq 'bb045mm1234 has no ESRI metadata file in staging'
+      expect(object_client).not_to have_received(:update)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

This allows for re-accessioning without having to restage all the files.

Fixes #1176

## How was this change tested? 🤨

ci


