### PR TITLE
Quiet warnings/logs during tests

### DIFF
--- a/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
+++ b/spec/robots/dor_repo/gis_assembly/extract_boundingbox_spec.rb
@@ -689,7 +689,7 @@ RSpec.describe Robots::DorRepo::GisAssembly::ExtractBoundingbox do
     end
 
     def ci?
-      cmd_result = GisRobotSuite.run_system_command("#{Settings.gdal_path}ogr2ogr --version", logger: Logger.new($stdout)) # provide a throw away logger
+      cmd_result = GisRobotSuite.run_system_command("#{Settings.gdal_path}ogr2ogr --version", logger: Logger.new(File::NULL)) # provide a throw away logger
       cmd_result[:stdout_str].include?('GDAL 3.11')
     end
 


### PR DESCRIPTION
This redirects logs to /dev/null so that they don't pollute test output anymore.
