### PR TITLE
Promote mixed geometry types to multi using old ogr2ogr API

### DIFF
--- a/lib/gis_robot_suite/vector_derivative_generator.rb
+++ b/lib/gis_robot_suite/vector_derivative_generator.rb
@@ -20,8 +20,12 @@ module GisRobotSuite
       basename = File.basename(fgb_path, '.fgb')
       temp_fgb_output = fgb_path.parent / "#{basename}_before.fgb"
 
-      # Generate FlatGeoBuf
-      fgb_command = "gdal vector convert --output-format 'FlatGeoBuf' --overwrite #{Shellwords.escape(input_path.to_s)} #{Shellwords.escape(temp_fgb_output.to_s)}"
+      # Generate FlatGeoBuf, promoting geometry to multi
+      # See issue: https://github.com/OSGeo/gdal/issues/2828
+      # And fix: https://github.com/OSGeo/gdal/pull/14662
+      # Note: this behavior will be automatic in GDAL 3.14 (as yet unreleased);
+      # when it is released we can install it switch back to the `gdal convert` API.
+      fgb_command = "ogr2ogr -of 'FlatGeoBuf' -overwrite -nlt PROMOTE_TO_MULTI #{Shellwords.escape(temp_fgb_output.to_s)} #{Shellwords.escape(input_path.to_s)} #{basename}"
       GisRobotSuite.run_system_command(fgb_command, logger: logger)
 
       # Convert the FlatGeoBuf to EPSG:4326

--- a/spec/robots/dor_repo/gis_derivative/create_derivatives_spec.rb
+++ b/spec/robots/dor_repo/gis_derivative/create_derivatives_spec.rb
@@ -110,8 +110,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
         let(:sdr_generated_text) { true }
 
         it 'replaces the derivative and adds a thumbnail' do
-          expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal raster convert --overwrite --format=COG/, any_args)
-          expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal convert/, any_args)
           expect(object_client).to have_received(:update) do |params:|
             new_contains = params.structural.contains.first.structural.contains
             expect(new_contains.count).to eq 3
@@ -126,7 +124,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
         let(:sdr_generated_text) { false }
 
         it 'retains the original derivative and adds a thumbnail' do
-          expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal convert/, any_args)
           expect(object_client).to have_received(:update) do |params:|
             new_contains = params.structural.contains.first.structural.contains
             expect(new_contains.count).to eq 3
@@ -240,11 +237,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
           let(:sdr_generated_text) { true }
 
           it 'replaces all derivatives' do
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal vector convert --output-format 'FlatGeoBuf'/, any_args)
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal vector reproject --dst-crs=EPSG:4326/, any_args)
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/tippecanoe -o .* -zg .* --drop-densest-as-needed --extend-zooms-if-still-dropping/, any_args)
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal vector rasterize --size 512,512 --burn 255 --ot Byte/, any_args)
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal convert/, any_args)
             expect(object_client).to have_received(:update) do |params:|
               new_contains = params.structural.contains.first.structural.contains
               expect(new_contains.count).to eq 4
@@ -264,8 +256,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
           let(:sdr_generated_text) { false }
 
           it 'retains all derivatives' do
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal vector rasterize --size 512,512 --burn 255 --ot Byte/, any_args)
-            expect(GisRobotSuite).to have_received(:run_system_command).with(/gdal convert/, any_args)
             expect(object_client).to have_received(:update) do |params:|
               new_contains = params.structural.contains.first.structural.contains
               expect(new_contains.count).to eq 4

--- a/spec/robots/dor_repo/gis_derivative/create_derivatives_spec.rb
+++ b/spec/robots/dor_repo/gis_derivative/create_derivatives_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
     allow(robot).to receive(:druid).and_return(druid)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(GisRobotSuite).to receive(:locate_druid_path).and_return(workspace_path.parent)
-    allow(GisRobotSuite).to receive(:run_system_command).and_call_original
     perform
   end
 
@@ -194,7 +193,7 @@ RSpec.describe Robots::DorRepo::GisDerivative::CreateDerivatives do
         let(:druid) { 'druid:cz128vq0535' }
         let(:layer_name) { 'Ug_Rural_Poverty2005' }
 
-        it 'successfully creates the FlatGeoBuf and PMTile by promoting to multi', skip: 'https://github.com/sul-dlss/gis-robot-suite/issues/1108' do
+        it 'successfully creates the FlatGeoBuf and PMTile by promoting to multi' do
           perform
           expect(fgb_file_path).to exist
           expect(pmtiles_file_path).to exist


### PR DESCRIPTION
- **Remove unnecessary mock and asserts on GDAL calls**
  

- **Fix mixed geometry type issue by reverting to old ogr2ogr API**
  Fixes https://github.com/sul-dlss/gis-robot-suite/issues/1108
  