### PR TITLE
add version awareness to run_robot script; lookup latest version if none supplied

### DIFF
--- a/bin/run_robot
+++ b/bin/run_robot
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 # Will run one robot as specified, either for a druid a file containing one druid per line
+# Run on the server only
 #
 # To run With Options
 # Options must be placed AFTER workflow and robot name
@@ -14,6 +15,7 @@ slop = Slop.parse do |o|
   o.string '-e', '--environment', 'Environment to run in (i.e. test, production). Defaults to development', default: 'development'
   o.string '-d', '--druid', 'One druid to run the robot with', required: true
   o.string '-f', '--file', 'One file containing a druid per line'
+  o.integer '-v', '--version', 'Object version to run the robot for. Defaults to the current version'
   o.on '--help' do
     puts o
     exit
@@ -40,5 +42,6 @@ druids = if opts[:file]
          end
 
 druids.each do |druid|
-  bot.perform druid
+  version = opts[:version] || Dor::Services::Client.object(druid).find.version
+  bot.perform druid, version
 end


### PR DESCRIPTION
## Why was this change made? 🤔

lyber-core 9.0.0 changed Robot#perform to require a version argument (sul-dlss/lyber-core#297), used to skip runs that target a superseded object version. Add a -v/--version option and default to the object's current version when it isn't given, so the script keeps working with the new lyber-core release.

To make compatible with new version aware robot changes.

See also:
- https://github.com/sul-dlss/common-accessioning/pull/1645
- https://github.com/sul-dlss/preservation_robots/pull/698
- https://github.com/sul-dlss/was_robot_suite/pull/886