### PR TITLE
Allow fetching preserved files with no use attribute

### DIFF
--- a/lib/robots/dor_repo/gis_derivative/fetch_files.rb
+++ b/lib/robots/dor_repo/gis_derivative/fetch_files.rb
@@ -3,7 +3,7 @@
 module Robots
   module DorRepo
     module GisDerivative
-      # Pulls all of the master object files from preservation into the staging area if they are not there already
+      # Pulls all of the files from preservation into the staging area if they are not there already
       class FetchFiles < Base
         def initialize
           super('gisDerivativeWF', 'fetch-files')
@@ -12,7 +12,7 @@ module Robots
         # available from LyberCore::Robot: druid, bare_druid, object_workflow, object_client, cocina_object, logger
         def perform_work
           @content_dir = Pathname(File.join(GisRobotSuite.locate_druid_path(bare_druid, type: :workspace), 'content'))
-          master_filenames.each do |filename|
+          original_filenames.each do |filename|
             location = workspace_path(filename)
             location.parent.mkpath unless location.parent.directory?
             next if location.exist?
@@ -31,11 +31,11 @@ module Robots
           @file_fetcher ||= GisRobotSuite::FileFetcher.new(druid:, logger:)
         end
 
-        # return a list of filenames that are the master files for the object
+        # return a list of filenames that are the source files for the object
         # iterate over all files in cocina_object.structural.contains, looking at mimetypes
         # return a list of filenames that are correct mimetype
-        def master_filenames
-          @master_filenames ||= files.map(&:filename)
+        def original_filenames
+          @original_filenames ||= files.map(&:filename)
         end
 
         # iterate through cocina structural contains and return all relevant File objects
@@ -45,11 +45,10 @@ module Robots
           end.compact
         end
 
-        # filter down fileset files that are in preservation and have the master role
+        # filter down fileset files that are in preservation and are not derivatives
         def preserved_files_for_fileset(fileset)
           fileset.structural.contains.select do |file|
-            file.administrative.sdrPreserve &&
-              file.use == 'master'
+            file.administrative.sdrPreserve && (file.use.nil? || file.use == 'master')
           end
         end
       end

--- a/spec/robots/dor_repo/gis_derivative/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/gis_derivative/fetch_files_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::FetchFiles do
       size: 46_508_117,
       version: 2,
       hasMimeType: 'application/zip',
-      use: 'master',
       administrative: {
         publish: true,
         sdrPreserve: true,
@@ -49,7 +48,6 @@ RSpec.describe Robots::DorRepo::GisDerivative::FetchFiles do
                              size: 46_508_117,
                              version: 2,
                              hasMimeType: 'application/zip',
-                             use: 'master',
                              administrative: {
                                publish: true,
                                sdrPreserve: true,
@@ -78,12 +76,57 @@ RSpec.describe Robots::DorRepo::GisDerivative::FetchFiles do
   context 'when fetching files is successful' do
     let(:fetch_success) { true }
 
-    it 'calls the write_file_with_retries method with correct files' do
-      expect(perform).to eq ['data.zip', 'data2.zip']
-      expect(file_fetcher).to have_received(:write_file_with_retries)
-        .with(filename: 'data.zip', location: workspace_path / 'data.zip', max_tries: 3)
-      expect(file_fetcher).to have_received(:write_file_with_retries)
-        .with(filename: 'data2.zip', location: workspace_path / 'data2.zip', max_tries: 3)
+    context 'when use: "master"' do
+      let(:data_file) do
+        Cocina::Models::File.new(
+          type: 'https://cocina.sul.stanford.edu/models/file',
+          externalIdentifier: 'https://cocina.sul.stanford.edu/file/vz757hs1282-vz757hs1282_1/data.zip',
+          label: 'data.zip',
+          filename: 'data.zip',
+          size: 46_508_117,
+          version: 2,
+          hasMimeType: 'application/zip',
+          use: 'master',
+          administrative: {
+            publish: true,
+            sdrPreserve: true,
+            shelve: true
+          }
+        )
+      end
+      let(:also_data) do
+        Cocina::Models::File.new(filename: 'data2.zip',
+                                 label: 'data2.zip',
+                                 type: 'https://cocina.sul.stanford.edu/models/file',
+                                 externalIdentifier: 'https://cocina.sul.stanford.edu/file/vz757hs1282-vz757hs1282_1/data.zip',
+                                 size: 46_508_117,
+                                 version: 2,
+                                 hasMimeType: 'application/zip',
+                                 use: 'master',
+                                 administrative: {
+                                   publish: true,
+                                   sdrPreserve: true,
+                                   shelve: true
+                                 })
+      end
+
+      it 'calls the write_file_with_retries method with correct files' do
+        expect(perform).to eq ['data.zip', 'data2.zip']
+        expect(file_fetcher).to have_received(:write_file_with_retries)
+          .with(filename: 'data.zip', location: workspace_path / 'data.zip', max_tries: 3)
+        expect(file_fetcher).to have_received(:write_file_with_retries)
+          .with(filename: 'data2.zip', location: workspace_path / 'data2.zip', max_tries: 3)
+      end
+    end
+
+    context 'when use: nil' do
+      it 'calls the write_file_with_retries method with correct files' do
+        expect(perform).to eq ['data.zip', 'data2.zip']
+        expect(file_fetcher).to have_received(:write_file_with_retries)
+          .with(filename: 'data.zip', location: workspace_path / 'data.zip', max_tries: 3)
+        expect(file_fetcher).to have_received(:write_file_with_retries)
+          .with(filename: 'data2.zip', location: workspace_path / 'data2.zip', max_tries: 3)
+      end
     end
   end
 


### PR DESCRIPTION


## Why was this change made? 🤔
At one time we set the use attribute to master, but files with a nil use are also considered original files


## How was this change tested? 🤨

ci


